### PR TITLE
Add .log export option and update MainForm to v0.7.5

### DIFF
--- a/AccountTester/ExportForm.Designer.cs
+++ b/AccountTester/ExportForm.Designer.cs
@@ -56,7 +56,7 @@
             // comboBoxExtension
             // 
             comboBoxExtension.FormattingEnabled = true;
-            comboBoxExtension.Items.AddRange(new object[] { ".txt", ".csv", ".xml", ".json" });
+            comboBoxExtension.Items.AddRange(new object[] { ".log", ".txt", ".csv", ".xml", ".json" });
             comboBoxExtension.Location = new Point(10, 127);
             comboBoxExtension.Name = "comboBoxExtension";
             comboBoxExtension.Size = new Size(188, 22);

--- a/AccountTester/ExportForm.cs
+++ b/AccountTester/ExportForm.cs
@@ -67,6 +67,9 @@
                 case ".txt":
                     ExportToTxt(fileName, filePath);
                     break;
+                case ".log":
+                    ExportToLog(fileName, filePath);
+                    break;
             }
         }
 
@@ -211,6 +214,18 @@
             */
 
             // Fermeture du StreamWriter
+            sw.Close();
+
+            MessageBox.Show("The report has been exported successfully.");
+            this.Close();
+        }
+
+        private void ExportToLog(string fileName, string filePath)
+        {
+            string path = Path.Combine(filePath, $"{fileName}.log");
+            using StreamWriter sw = new(path);
+
+            sw.Write(ExportVariables.General_export_Resume);
             sw.Close();
 
             MessageBox.Show("The report has been exported successfully.");

--- a/AccountTester/MainForm.Designer.cs
+++ b/AccountTester/MainForm.Designer.cs
@@ -103,7 +103,7 @@
             Icon = (Icon)resources.GetObject("$this.Icon");
             MaximizeBox = false;
             Name = "MainForm";
-            Text = "Account Tester v0.7";
+            Text = "Account Tester v0.8";
             ResumeLayout(false);
             PerformLayout();
         }

--- a/AccountTester/MainForm.Designer.cs
+++ b/AccountTester/MainForm.Designer.cs
@@ -103,7 +103,7 @@
             Icon = (Icon)resources.GetObject("$this.Icon");
             MaximizeBox = false;
             Name = "MainForm";
-            Text = "Account Tester v0.8";
+            Text = "Account Tester v0.7.5";
             ResumeLayout(false);
             PerformLayout();
         }

--- a/AccountTester/MainForm.cs
+++ b/AccountTester/MainForm.cs
@@ -318,7 +318,11 @@ namespace AccountTester
             {
                 Stopwatch stopwatch = new();
                 stopwatch.Start();
+                richTextBoxLogs.AppendText("AccountTester - Rapport de test" + Environment.NewLine);
+                richTextBoxLogs.AppendText(DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss") + Environment.NewLine);
+                richTextBoxLogs.AppendText(Environment.NewLine);
 
+                richTextBoxLogs.AppendText("----------------------------------------" + Environment.NewLine);
                 richTextBoxLogs.AppendText($"#### Utilisateur :" + Environment.NewLine);
                 richTextBoxLogs.AppendText($"- {ExportVariables.General_export_UserName}" + Environment.NewLine);
                 richTextBoxLogs.AppendText(Environment.NewLine);


### PR DESCRIPTION
Purpose :
- Fix #8 

Details :
- Updated `comboBoxExtension` in `ExportForm.Designer.cs` to include `.log`.
- Added a new case for `.log` in `ExportForm.cs` to handle log file export.
- Implemented `ExportToLog` method in `ExportForm.cs` for exporting to `.log` files.
- Changed `Text` property of `MainForm` in `MainForm.Designer.cs` to "Account Tester v0.7.5".
- Enhanced `richTextBoxLogs` in `MainForm.cs` with header, timestamp, and separators for better log readability.