### PR TITLE
Disable buttons during tests and reset test counters

### DIFF
--- a/AccountTester/MainForm.Designer.cs
+++ b/AccountTester/MainForm.Designer.cs
@@ -103,7 +103,7 @@
             Icon = (Icon)resources.GetObject("$this.Icon");
             MaximizeBox = false;
             Name = "MainForm";
-            Text = "Account Tester v0.7.5";
+            Text = "Account Tester v0.7.6";
             ResumeLayout(false);
             PerformLayout();
         }

--- a/AccountTester/MainForm.cs
+++ b/AccountTester/MainForm.cs
@@ -312,6 +312,8 @@ namespace AccountTester
         /// <returns></returns>
         async Task ExecutionSequentielle()
         {
+            buttonCopier.Enabled = false;
+            buttonExportForm.Enabled = false;
             richTextBoxLogs.Clear();
 
             try
@@ -360,6 +362,8 @@ namespace AccountTester
                 stopwatch.Stop();
                 richTextBoxLogs.AppendText("- Total temps écoulé : " + stopwatch.ElapsedMilliseconds + " ms" + Environment.NewLine);
                 richTextBoxLogs.AppendText($"- Tests réussi : {ExportVariables.General_export_TotalSuccess}/{ExportVariables.General_export_TotalTests}");
+                ExportVariables.General_export_TotalSuccess = 0;
+                ExportVariables.General_export_TotalTests = 0;
 
                 // Play a sound when the tests are done
                 System.Media.SoundPlayer player = new(@"C:\Windows\Media\Windows Message Nudge.wav");


### PR DESCRIPTION
Purpose:
- Fix #10 

Details:
- Disabled `buttonCopier` and `buttonExportForm` in `ExecutionSequentielle` method to prevent user interaction during test execution.
- Reset `General_export_TotalSuccess` and `General_export_TotalTests` variables to `0` after tests complete to clear test counts for the next run.