### PR TITLE
Amélioration de l'exportation

### DIFF
--- a/AccountTester/ExportForm.cs
+++ b/AccountTester/ExportForm.cs
@@ -148,8 +148,22 @@ namespace AccountTester
             sw.WriteLine("Office");
             sw.WriteLine("-----------------------------------");
             sw.WriteLine($"{T("Hour")}: {ExportVariables.OfficeVersion_export_Hour}");
-            sw.WriteLine($"{T("OfficeVersion")}: {ExportVariables.OfficeVersion_export_OfficeVersion}");
-            sw.WriteLine($"{T("OfficePath")}: {ExportVariables.OfficeVersion_export_OfficePath}");
+            if (ExportVariables.OfficeVersion_export_OfficeVersion.Split(',').Length > 0)
+            {
+                sw.WriteLine($"{T("OfficeVersion")}:");
+                foreach (string version in ExportVariables.OfficeVersion_export_OfficeVersion.Split(','))
+                {
+                    sw.WriteLine($"- {version}");
+                }
+                sw.WriteLine($"{T("Path")}: {ExportVariables.OfficeVersion_export_OfficePath}");
+                sw.WriteLine($"{T("Culture")}: {ExportVariables.OfficeVersion_export_OfficeCulture}");
+                sw.WriteLine($"{T("ExcludedApps")}: {ExportVariables.OfficeVersion_export_OfficeExcludedApps}");
+                sw.WriteLine($"{T("LastUpdateStatus")}: {ExportVariables.OfficeVersion_export_OfficeLastUpdateStatus}");
+            }
+            else
+            {
+                sw.WriteLine(T("MainForm_RTBL_PrinterTesting_NotFound"));
+            }
             sw.WriteLine($"{T("ElapsedTime")}: {ExportVariables.OfficeVersion_export_ElapsedTime} ms\n\n");
 
             sw.WriteLine(T("OfficeRights"));
@@ -246,6 +260,9 @@ namespace AccountTester
             XMLW(doc, officeVersion, TT("Hour"), ExportVariables.OfficeVersion_export_Hour);
             XMLW(doc, officeVersion, TT("Version"), ExportVariables.OfficeVersion_export_OfficeVersion);
             XMLW(doc, officeVersion, TT("Path"), ExportVariables.OfficeVersion_export_OfficePath);
+            XMLW(doc, officeVersion, TT("Culture"), ExportVariables.OfficeVersion_export_OfficeCulture);
+            XMLW(doc, officeVersion, TT("ExcludedApps"), ExportVariables.OfficeVersion_export_OfficeExcludedApps);
+            XMLW(doc, officeVersion, TT("LastUpdateStatus"), ExportVariables.OfficeVersion_export_OfficeLastUpdateStatus);
             XMLW(doc, officeVersion, TT("ElapsedTime"), ExportVariables.OfficeVersion_export_ElapsedTime);
 
             XmlElement officeRights = doc.CreateElement(TT("OfficeRights"));
@@ -367,8 +384,11 @@ namespace AccountTester
                     CSVWL(T("OfficeVersion"), T("Version"), version, sw);
                 }
             }
-            CSVWL(T("OfficeVersion"), "Chemin d'Office", ExportVariables.OfficeVersion_export_OfficePath, sw);
-            CSVWL(T("OfficeVersion"), "Time elapsed (ms)", ExportVariables.OfficeVersion_export_ElapsedTime, sw);
+            CSVWL(T("OfficeVersion"), T("OfficePath"), ExportVariables.OfficeVersion_export_OfficePath, sw);
+            CSVWL(T("OfficeVersion"), T("Culture"), ExportVariables.OfficeVersion_export_OfficeCulture, sw);
+            CSVWL(T("OfficeVersion"), T("ExcludedApps"), ExportVariables.OfficeVersion_export_OfficeExcludedApps, sw);
+            CSVWL(T("OfficeVersion"), T("LastUpdateStatus"), ExportVariables.OfficeVersion_export_OfficeLastUpdateStatus, sw);
+            CSVWL(T("OfficeVersion"), $"{T("ElapsedTime")} (ms)", ExportVariables.OfficeVersion_export_ElapsedTime, sw);
 
             CSVWL(T("OfficeRights"), T("Hour"), ExportVariables.OfficeRights_export_Hour, sw);
             CSVWL(T("OfficeRights"), T("CanWrite"), ExportVariables.OfficeRights_export_CanWrite, sw);
@@ -454,7 +474,10 @@ namespace AccountTester
             {
                 [TT("Hour")] = ExportVariables.OfficeVersion_export_Hour,
                 [TT("OfficeVersion")] = ExportVariables.OfficeVersion_export_OfficeVersion,
-                [TT("OfficePath")] = ExportVariables.OfficeVersion_export_OfficePath,
+                [TT("Path")] = ExportVariables.OfficeVersion_export_OfficePath,
+                [TT("Culture")] = ExportVariables.OfficeVersion_export_OfficeCulture,
+                [TT("ExcludedApps")] = ExportVariables.OfficeVersion_export_OfficeExcludedApps,
+                [TT("LastUpdateStatus")] = ExportVariables.OfficeVersion_export_OfficeLastUpdateStatus,
                 [TT("ElapsedTime")] = ExportVariables.OfficeVersion_export_ElapsedTime
             };
 

--- a/AccountTester/ExportForm.cs
+++ b/AccountTester/ExportForm.cs
@@ -167,15 +167,15 @@ namespace AccountTester
             sw.WriteLine(T("Printer"));
             sw.WriteLine("-----------------------------------");
             sw.WriteLine($"{T("Hour")}: {ExportVariables.Printer_export_Hour}");
-            sw.WriteLine($"{T("Name")}:");
             if (ExportVariables.Printer_export_PrinterName != null)
             {
                 foreach (string printerName in ExportVariables.Printer_export_PrinterName)
                 {
-                    sw.WriteLine($"- {printerName}");
-                    sw.WriteLine($"{T("Status")}: {ExportVariables.Printer_export_PrinterStatus?[i]}");
-                    sw.WriteLine($"{T("Driver")}: {ExportVariables.Printer_export_PrinterDriver?[i]}");
-                    sw.WriteLine($"{T("Port")}: {ExportVariables.Printer_export_PrinterPort?[i]}");
+                    sw.WriteLine($"{T("Name")}: {printerName}");
+                    sw.WriteLine($"- {T("IP")}: {ExportVariables.Printer_export_PrinterIP?[i]}");
+                    sw.WriteLine($"- {T("Status")}: {ExportVariables.Printer_export_PrinterStatus?[i]}");
+                    sw.WriteLine($"- {T("Driver")}: {ExportVariables.Printer_export_PrinterDriver?[i]}");
+                    sw.WriteLine($"- {T("Port")}: {ExportVariables.Printer_export_PrinterPort?[i]}");
                     i++;
                 }
             }
@@ -259,14 +259,22 @@ namespace AccountTester
             XMLW(doc, officeRights, TT("TestedFolder"), ExportVariables.OfficeRights_export_FolderTested);
             XMLW(doc, officeRights, TT("ElapsedTime"), ExportVariables.OfficeRights_export_ElapsedTime);
 
-            XmlElement printer = doc.CreateElement(TT("Printer"));
-            root.AppendChild(printer);
-            XMLW(doc, printer, TT("Hour"), ExportVariables.Printer_export_Hour);
-            XMLWL(doc, printer, TT("Printer") + TT("Name"), ExportVariables.Printer_export_PrinterName, TT("Printer"));
-            XMLWL(doc, printer, TT("Printer") + TT("Status"), ExportVariables.Printer_export_PrinterStatus, TT("Status"));
-            XMLWL(doc, printer, TT("Printer") + TT("Driver"), ExportVariables.Printer_export_PrinterDriver, TT("Driver"));
-            XMLWL(doc, printer, TT("Printer") + TT("Port"), ExportVariables.Printer_export_PrinterPort, TT("Port"));
-            XMLW(doc, printer, TT("ElapsedTime"), ExportVariables.Printer_export_ElapsedTime);
+            XmlElement printers = doc.CreateElement(TT("Printer"));
+            root.AppendChild(printers);
+            XMLW(doc, printers, TT("Hour"), ExportVariables.Printer_export_Hour);
+
+            for (int i = 0; i < ExportVariables.Printer_export_PrinterName?.Length; i++)
+            {
+                XmlElement printer = doc.CreateElement($"{TT("Printer")}_{i}");
+                printers.AppendChild(printer);
+                XMLW(doc, printer, TT("Name"), ExportVariables.Printer_export_PrinterName[i]);
+                XMLW(doc, printer, TT("IP"), ExportVariables.Printer_export_PrinterIP[i]);
+                XMLW(doc, printer, TT("Status"), ExportVariables.Printer_export_PrinterStatus[i]);
+                XMLW(doc, printer, TT("Driver"), ExportVariables.Printer_export_PrinterDriver[i]);
+                XMLW(doc, printer, TT("Port"), ExportVariables.Printer_export_PrinterPort[i]);
+            }
+
+            XMLW(doc, printers, TT("ElapsedTime"), ExportVariables.Printer_export_ElapsedTime);
 
             string path = Path.Combine(filePath, $"{fileName}.xml");
             doc.Save(path);
@@ -376,10 +384,11 @@ namespace AccountTester
             {
                 for (int i = 0; i < ExportVariables.Printer_export_PrinterName.Length; i++)
                 {
-                    CSVWL(T("Printer"), T("Name"), ExportVariables.Printer_export_PrinterName[i], sw);
-                    CSVWL(T("Printer"), T("Status"), ExportVariables.Printer_export_PrinterStatus?[i], sw);
-                    CSVWL(T("Printer"), T("Driver"), ExportVariables.Printer_export_PrinterDriver?[i], sw);
-                    CSVWL(T("Printer"), T("Port"), ExportVariables.Printer_export_PrinterPort?[i], sw);
+                    CSVWL($"{T("Printer")}_{i}", T("Name"), ExportVariables.Printer_export_PrinterName[i], sw);
+                    CSVWL($"{T("Printer")}_{i}", T("Status"), ExportVariables.Printer_export_PrinterStatus?[i], sw);
+                    CSVWL($"{T("Printer")}_{i}", T("IP"), ExportVariables.Printer_export_PrinterIP?[i], sw);
+                    CSVWL($"{T("Printer")}_{i}", T("Driver"), ExportVariables.Printer_export_PrinterDriver?[i], sw);
+                    CSVWL($"{T("Printer")}_{i}", T("Port"), ExportVariables.Printer_export_PrinterPort?[i], sw);
                 }
             }
             else
@@ -408,65 +417,89 @@ namespace AccountTester
         /// <param name="filePath">json saving path</param>
         private static void ExportToJSON(string fileName, string filePath)
         {
-            var Block = new
+            var Printers = new Dictionary<string, object>
             {
-                Title = fileName,
-                Date = ExportVariables.General_DateAndHour,
-                Username = ExportVariables.General_export_UserName,
-                General = new
-                {
-                    OperatingSystem = ExportVariables.General_export_DeviceOS,
-                    OSArchitecture = ExportVariables.General_export_OSArchitecture,
-                    TotalTests = ExportVariables.General_export_TotalTests,
-                    TotalSuccess = ExportVariables.General_export_TotalSuccess
-                },
-                InternetConnection = new
-                {
-                    Hour = ExportVariables.InternetConnexion_export_Hour,
-                    TestedURL = ExportVariables.InternetConnexion_export_TestedURL,
-                    HTMLStatus = ExportVariables.InternetConnexion_export_HTMLStatut,
-                    ResponseTime = ExportVariables.InternetConnexion_export_ElapsedTime
-                },
-                NetworkStorageRights = new
-                {
-                    Hour = ExportVariables.NetworkStorageRights_export_Hour,
-                    ConnexionType = ExportVariables.NetworkStorageRights_export_ConnexionType,
-                    DiskLetter = ExportVariables.NetworkStorageRights_export_DiskLetter,
-                    UNCPath = ExportVariables.NetworkStorageRights_export_CheminUNC,
-                    Server = ExportVariables.NetworkStorageRights_export_Serveur,
-                    ShareName = ExportVariables.NetworkStorageRights_export_ShareName,
-                    ElapsedTime = ExportVariables.NetworkStorageRights_export_ElapsedTime
-                },
-                OfficeVersion = new
-                {
-                    Hour = ExportVariables.OfficeVersion_export_Hour,
-                    OfficeVersion = ExportVariables.OfficeVersion_export_OfficeVersion,
-                    OfficePath = ExportVariables.OfficeVersion_export_OfficePath,
-                    ElapsedTime = ExportVariables.OfficeVersion_export_ElapsedTime
-                },
-                OfficeRights = new
-                {
-                    Hour = ExportVariables.OfficeRights_export_Hour,
-                    CanWrite = ExportVariables.OfficeRights_export_CanWrite,
-                    CanRead = ExportVariables.OfficeRights_export_CanRead,
-                    CanDelete = ExportVariables.OfficeRights_export_CanDelete,
-                    CanCreate = ExportVariables.OfficeRights_export_CanCreate,
-                    CanSave = ExportVariables.OfficeRights_export_CanSave,
-                    TestedFolder = ExportVariables.OfficeRights_export_FolderTested,
-                    ElapsedTime = ExportVariables.OfficeRights_export_ElapsedTime
-                },
-                Printer = new
-                {
-                    Hour = ExportVariables.Printer_export_Hour,
-                    PrinterName = ExportVariables.Printer_export_PrinterName,
-                    PrinterStatus = ExportVariables.Printer_export_PrinterStatus,
-                    PrinterDriver = ExportVariables.Printer_export_PrinterDriver,
-                    PrinterPort = ExportVariables.Printer_export_PrinterPort,
-                    ElapsedTime = ExportVariables.Printer_export_ElapsedTime
-                }
+                [TT("Hour")] = ExportVariables.Printer_export_Hour,
             };
 
-            string jsonString = JsonSerializer.Serialize(Block, CachedJsonSerializerOptions);
+            int printerCount = ExportVariables.Printer_export_PrinterName?.Length ?? 0;
+            for (int i = 0; i < printerCount; i++)
+            {
+                var printer = new Dictionary<string, object>
+                {
+                    [TT("Name")] = ExportVariables.Printer_export_PrinterName[i],
+                    [TT("IP")] = ExportVariables.Printer_export_PrinterIP[i],
+                    [TT("Status")] = ExportVariables.Printer_export_PrinterStatus[i],
+                    [TT("Driver")] = ExportVariables.Printer_export_PrinterDriver[i],
+                    [TT("Port")] = ExportVariables.Printer_export_PrinterPort[i]
+                };
+
+                Printers[$"{TT("Printer")}_{i + 1}"] = printer;
+            }
+            Printers[TT("ElapsedTime")] = ExportVariables.Printer_export_ElapsedTime;
+
+            var OfficeRights = new Dictionary<string, object>
+            {
+                [TT("Hour")] = ExportVariables.OfficeRights_export_Hour,
+                [TT("CanWrite")] = ExportVariables.OfficeRights_export_CanWrite,
+                [TT("CanRead")] = ExportVariables.OfficeRights_export_CanRead,
+                [TT("CanDelete")] = ExportVariables.OfficeRights_export_CanDelete,
+                [TT("CanCreate")] = ExportVariables.OfficeRights_export_CanCreate,
+                [TT("CanSave")] = ExportVariables.OfficeRights_export_CanSave,
+                [TT("TestedFolder")] = ExportVariables.OfficeRights_export_FolderTested,
+                [TT("ElapsedTime")] = ExportVariables.OfficeRights_export_ElapsedTime
+            };
+
+            var OfficeVersion = new Dictionary<string, object>
+            {
+                [TT("Hour")] = ExportVariables.OfficeVersion_export_Hour,
+                [TT("OfficeVersion")] = ExportVariables.OfficeVersion_export_OfficeVersion,
+                [TT("OfficePath")] = ExportVariables.OfficeVersion_export_OfficePath,
+                [TT("ElapsedTime")] = ExportVariables.OfficeVersion_export_ElapsedTime
+            };
+
+
+            var NetworkStorageRights = new Dictionary<string, object>
+            {
+                [TT("Hour")] = ExportVariables.NetworkStorageRights_export_Hour,
+                [TT("ConnexionType")] = ExportVariables.NetworkStorageRights_export_ConnexionType,
+                [TT("DiskLetter")] = ExportVariables.NetworkStorageRights_export_DiskLetter,
+                [TT("UNCPath")] = ExportVariables.NetworkStorageRights_export_CheminUNC,
+                [T("Server")] = ExportVariables.NetworkStorageRights_export_Serveur,
+                [TT("ShareName")] = ExportVariables.NetworkStorageRights_export_ShareName,
+                [TT("ElapsedTime")] = ExportVariables.NetworkStorageRights_export_ElapsedTime
+            };
+
+            var InternetConnexion = new Dictionary<string, object>
+            {
+                [TT("Hour")] = ExportVariables.InternetConnexion_export_Hour,
+                [TT("TestedURL")] = ExportVariables.InternetConnexion_export_TestedURL,
+                [TT("HTMLStatus")] = ExportVariables.InternetConnexion_export_HTMLStatut,
+                [TT("ResponseTime")] = ExportVariables.InternetConnexion_export_ElapsedTime
+            };
+
+            var General = new Dictionary<string, object>
+            {
+                [TT("OperatingSystem")] = ExportVariables.General_export_DeviceOS,
+                [TT("OSArchitecture")] = ExportVariables.General_export_OSArchitecture,
+                [TT("TotalTests")] = ExportVariables.General_export_TotalTests,
+                [TT("TotalSuccess")] = ExportVariables.General_export_TotalSuccess,
+            };
+
+            var block = new Dictionary<string, object>
+            {
+                [TT("Title")] = fileName,
+                [TT("Date")] = ExportVariables.General_DateAndHour,
+                [TT("Username")] = ExportVariables.General_export_UserName,
+                [TT("General")] = General,
+                [TT("InternetConnexion")] = InternetConnexion,
+                [TT("NetworkStorageRights")] = NetworkStorageRights,
+                [TT("OfficeVersion")] = OfficeVersion,
+                [TT("OfficeRights")] = OfficeRights,
+                [TT("Printer")] = Printers
+            };
+
+            string jsonString = JsonSerializer.Serialize(block, CachedJsonSerializerOptions);
             File.WriteAllText($"{filePath}\\{fileName}.json", jsonString);
         }
 

--- a/AccountTester/ExportVariables.cs
+++ b/AccountTester/ExportVariables.cs
@@ -4,24 +4,24 @@
     {
         // Variables for ExportForm, valus are set by the MainForm.cs
 
-        // General variables
-        public static string General_export_DeviceOS = Convert.ToUInt32(Environment.OSVersion.Version.ToString().Split('.')[2]) >= 22631 ? "Windows 11" : "Windows 10";  // OK 
+        // General variables - OK
+        public static string General_export_DeviceOS = Convert.ToUInt32(Environment.OSVersion.Version.ToString().Split('.')[2]) >= 22631 ? "Windows 11" : "Windows 10";
 
-        public static string General_export_OSArchitecture = Environment.Is64BitOperatingSystem ? "64 bits" : "32 bits" ?? "Error";  // OK
+        public static string General_export_OSArchitecture = Environment.Is64BitOperatingSystem ? "64 bits" : "32 bits" ?? "Error";
 
-        public static string General_export_UserName = Environment.UserName; // OK
+        public static string General_export_UserName = Environment.UserName;
 
-        public static string General_DateAndHour = DateTime.Now.ToString("dd/MM/yyyy HH:mm:ss"); // OK
-        public static int General_export_TotalTests { get; set; } // Not right value in report
-        public static int General_export_TotalSuccess { get; set; } // Not right value in report
-        public static string General_export_Resume { get; set; } = "Null"; // OK
+        public static string General_DateAndHour = DateTime.Now.ToString("dd/MM/yyyy HH:mm:ss");
+        public static int General_export_TotalTests { get; set; }
+        public static int General_export_TotalSuccess { get; set; }
+        public static string General_export_Resume { get; set; } = "Null";
 
-        // Internet Connection variables
-        public static string InternetConnexion_export_Hour { get; set; } = "Null";    // OK
+        // Internet Connection variables - OK
+        public static string InternetConnexion_export_Hour { get; set; } = "Null";
 
-        public static string InternetConnexion_export_TestedURL = "https://www.google.ch"; // OK
-        public static string InternetConnexion_export_HTMLStatut { get; set; } = "Null";  // OK
-        public static string InternetConnexion_export_ElapsedTime { get; set; } = "Null"; // OK
+        public static string InternetConnexion_export_TestedURL = "https://www.google.ch";
+        public static string InternetConnexion_export_HTMLStatut { get; set; } = "Null";
+        public static string InternetConnexion_export_ElapsedTime { get; set; } = "Null";
 
         // NetworkStorageRights variables 
         public static string NetworkStorageRights_export_Hour { get; set; } = "Null";     // OK
@@ -39,22 +39,23 @@
         public static string OfficeVersion_export_ElapsedTime { get; set; } = "Null";    // OK
 
         // OfficeRights variables - OK
-        public static string OfficeRights_export_Hour { get; set; } = "Null";      // OK
-        public static string OfficeRights_export_CanWrite { get; set; } = "Null";    // OK
-        public static string OfficeRights_export_CanRead { get; set; } = "Null";      // OK
-        public static string OfficeRights_export_CanDelete { get; set; } = "Null";      // OK
-        public static string OfficeRights_export_CanSave { get; set; } = "Null";     // OK
-        public static string OfficeRights_export_CanCreate { get; set; } = "Null";     // OK
+        public static string OfficeRights_export_Hour { get; set; } = "Null";
+        public static string OfficeRights_export_CanWrite { get; set; } = "Null";
+        public static string OfficeRights_export_CanRead { get; set; } = "Null";
+        public static string OfficeRights_export_CanDelete { get; set; } = "Null";
+        public static string OfficeRights_export_CanSave { get; set; } = "Null";
+        public static string OfficeRights_export_CanCreate { get; set; } = "Null";
 
-        public static string OfficeRights_export_FolderTested = Path.GetTempPath();  // OK
-        public static string OfficeRights_export_ElapsedTime { get; set; } = "Null";     // OK
+        public static string OfficeRights_export_FolderTested = Path.GetTempPath();
+        public static string OfficeRights_export_ElapsedTime { get; set; } = "Null";
 
         // Printer variables
         public static string Printer_export_Hour { get; set; } = "Null";     // Ok
-        public static string[]? Printer_export_PrinterName { get; set; }      // Incorrect in report
-        public static string[]? Printer_export_PrinterStatus { get; set; }
-        public static string[]? Printer_export_PrinterDriver { get; set; }
-        public static string[]? Printer_export_PrinterPort { get; set; }
+        public static string[] Printer_export_PrinterName { get; set; } = []; // Incorrect in report
+        public static string[] Printer_export_PrinterIP { get; set; } = []; // Not set
+        public static string[] Printer_export_PrinterStatus { get; set; } = [];  // Not set
+        public static string[] Printer_export_PrinterDriver { get; set; } = []; // To test
+        public static string[] Printer_export_PrinterPort { get; set; } = []; // To test 
         public static string Printer_export_ElapsedTime { get; set; } = "Null";      // OK
     }
 }

--- a/AccountTester/ExportVariables.cs
+++ b/AccountTester/ExportVariables.cs
@@ -2,9 +2,9 @@
 {
     internal class ExportVariables
     {
-        // Variables for ExportForm, valus are set by the MainForm.cs
+        // Variables for ExportForm, valus are set by the MainForm functions
 
-        // General variables - OK
+        // General variables
         public static string General_export_DeviceOS = Convert.ToUInt32(Environment.OSVersion.Version.ToString().Split('.')[2]) >= 22631 ? "Windows 11" : "Windows 10";
 
         public static string General_export_OSArchitecture = Environment.Is64BitOperatingSystem ? "64 bits" : "32 bits" ?? "Error";
@@ -16,29 +16,32 @@
         public static int General_export_TotalSuccess { get; set; }
         public static string General_export_Resume { get; set; } = "Null";
 
-        // Internet Connection variables - OK
+        // Internet Connection variables
         public static string InternetConnexion_export_Hour { get; set; } = "Null";
 
         public static string InternetConnexion_export_TestedURL = "https://www.google.ch";
         public static string InternetConnexion_export_HTMLStatut { get; set; } = "Null";
         public static string InternetConnexion_export_ElapsedTime { get; set; } = "Null";
 
-        // NetworkStorageRights variables 
-        public static string NetworkStorageRights_export_Hour { get; set; } = "Null";     // OK
+        // NetworkStorageRights variables - Not OK, need to be tested with a network share
+        public static string NetworkStorageRights_export_Hour { get; set; } = "Null";
         public static string NetworkStorageRights_export_ConnexionType { get; set; } = "Null"; // Not set
         public static string[]? NetworkStorageRights_export_DiskLetter { get; set; }  // Not set
         public static string[]? NetworkStorageRights_export_CheminUNC { get; set; } // Not set
         public static string[]? NetworkStorageRights_export_Serveur { get; set; } // Not set
         public static string[]? NetworkStorageRights_export_ShareName { get; set; } // Not set
-        public static string NetworkStorageRights_export_ElapsedTime { get; set; } = "Null"; // OK
+        public static string NetworkStorageRights_export_ElapsedTime { get; set; } = "Null";
 
         // OfficeVersion variables
-        public static string OfficeVersion_export_Hour { get; set; } = "Null"; // OK
-        public static string OfficeVersion_export_OfficeVersion { get; set; } = "Null";  // OK
-        public static string OfficeVersion_export_OfficePath { get; set; } = "Null"; // Not set
-        public static string OfficeVersion_export_ElapsedTime { get; set; } = "Null";    // OK
+        public static string OfficeVersion_export_Hour { get; set; } = "Null";
+        public static string OfficeVersion_export_OfficeVersion { get; set; } = "Null"; 
+        public static string OfficeVersion_export_OfficePath { get; set; } = "Null"; 
+        public static string OfficeVersion_export_OfficeCulture { get; set; } = "Null";
+        public static string OfficeVersion_export_OfficeExcludedApps { get; set; } = "Null"; 
+        public static string OfficeVersion_export_OfficeLastUpdateStatus { get; set; } = "Null"; 
+        public static string OfficeVersion_export_ElapsedTime { get; set; } = "Null";    
 
-        // OfficeRights variables - OK
+        // OfficeRights variables
         public static string OfficeRights_export_Hour { get; set; } = "Null";
         public static string OfficeRights_export_CanWrite { get; set; } = "Null";
         public static string OfficeRights_export_CanRead { get; set; } = "Null";
@@ -50,12 +53,12 @@
         public static string OfficeRights_export_ElapsedTime { get; set; } = "Null";
 
         // Printer variables
-        public static string Printer_export_Hour { get; set; } = "Null";     // Ok
-        public static string[] Printer_export_PrinterName { get; set; } = []; // Incorrect in report
-        public static string[] Printer_export_PrinterIP { get; set; } = []; // Not set
-        public static string[] Printer_export_PrinterStatus { get; set; } = [];  // Not set
-        public static string[] Printer_export_PrinterDriver { get; set; } = []; // To test
-        public static string[] Printer_export_PrinterPort { get; set; } = []; // To test 
-        public static string Printer_export_ElapsedTime { get; set; } = "Null";      // OK
+        public static string Printer_export_Hour { get; set; } = "Null";
+        public static string[] Printer_export_PrinterName { get; set; } = [];
+        public static string[] Printer_export_PrinterIP { get; set; } = [];
+        public static string[] Printer_export_PrinterStatus { get; set; } = [];
+        public static string[] Printer_export_PrinterDriver { get; set; } = [];
+        public static string[] Printer_export_PrinterPort { get; set; } = [];
+        public static string Printer_export_ElapsedTime { get; set; } = "Null";
     }
 }

--- a/AccountTester/LangManager.cs
+++ b/AccountTester/LangManager.cs
@@ -11,12 +11,18 @@ namespace AccountTester
         private CultureInfo _culture;
         public event Action? LanguageChanged;
 
+        /// <summary>
+        /// Singleton instance of the LangManager.
+        /// </summary>
         private LangManager()
         {
             _resourceManager = new ResourceManager("AccountTester.strings", typeof(LangManager).Assembly);
             _culture = new CultureInfo("en-US");
         }
 
+        /// <summary>
+        /// Gets the singleton instance of the LangManager.
+        /// </summary>
         public static LangManager Instance
         {
             get
@@ -26,17 +32,31 @@ namespace AccountTester
             }
         }
 
+        /// <summary>
+        /// Sets the language for translations.
+        /// </summary>
+        /// <param name="cultureCode"></param>
         public void SetLanguage(string cultureCode)
         {
             _culture = new CultureInfo(cultureCode);
             LanguageChanged?.Invoke();
         }
 
+        /// <summary>
+        /// Translates a given key to the current language.
+        /// </summary>
+        /// <param name="key">The name of the string in the resource file.</param>
+        /// <returns>Returns the value from the resource file if found, otherwise returns the key wrapped in exclamation marks.</returns>
         public string Translate(string key)
         {
             return _resourceManager.GetString(key, _culture) ?? $"!{key}!";
         }
 
+        /// <summary>
+        /// Translates a given key to the current language, remove the diacritics and trims it to a single word in PascalCase format. 
+        /// </summary>
+        /// <param name="key">The name of the string in the resource file.</param>
+        /// <returns>Returns the result as a single word without spaces.</returns>
         public string TrimTranslate(string key)
         {
             var translation = _resourceManager.GetString(key, _culture) ?? $"!{key}!";
@@ -48,6 +68,9 @@ namespace AccountTester
             return string.Join("", words);
         }
 
+        /// <summary>
+        /// Removes diacritics from a string.
+        /// </summary>
         static string RemoveDiacritics(string text)
         {
             var normalized = text.Normalize(NormalizationForm.FormD);
@@ -61,7 +84,5 @@ namespace AccountTester
 
             return sb.ToString().Normalize(NormalizationForm.FormC);
         }
-
-        public string CurrentCulture => _culture.Name;
     }
 }

--- a/AccountTester/MainForm.Designer.cs
+++ b/AccountTester/MainForm.Designer.cs
@@ -36,7 +36,7 @@
             labelLogs = new Label();
             menuStrip1 = new MenuStrip();
             optionsToolStripMenuItem = new ToolStripMenuItem();
-            langageToolStripMenuItem = new ToolStripMenuItem();
+            languageToolStripMenuItem = new ToolStripMenuItem();
             enUSToolStripMenuItem = new ToolStripMenuItem();
             frFRToolStripMenuItem = new ToolStripMenuItem();
             label1 = new Label();
@@ -107,29 +107,29 @@
             // 
             // optionsToolStripMenuItem
             // 
-            optionsToolStripMenuItem.DropDownItems.AddRange(new ToolStripItem[] { langageToolStripMenuItem });
+            optionsToolStripMenuItem.DropDownItems.AddRange(new ToolStripItem[] { languageToolStripMenuItem });
             optionsToolStripMenuItem.Name = "optionsToolStripMenuItem";
             optionsToolStripMenuItem.Size = new Size(61, 20);
             optionsToolStripMenuItem.Text = "Options";
             // 
-            // langageToolStripMenuItem
+            // languageToolStripMenuItem
             // 
-            langageToolStripMenuItem.DropDownItems.AddRange(new ToolStripItem[] { enUSToolStripMenuItem, frFRToolStripMenuItem });
-            langageToolStripMenuItem.Name = "langageToolStripMenuItem";
-            langageToolStripMenuItem.Size = new Size(119, 22);
-            langageToolStripMenuItem.Text = "Langage";
+            languageToolStripMenuItem.DropDownItems.AddRange(new ToolStripItem[] { enUSToolStripMenuItem, frFRToolStripMenuItem });
+            languageToolStripMenuItem.Name = "languageToolStripMenuItem";
+            languageToolStripMenuItem.Size = new Size(180, 22);
+            languageToolStripMenuItem.Text = "Language";
             // 
             // enUSToolStripMenuItem
             // 
             enUSToolStripMenuItem.Name = "enUSToolStripMenuItem";
-            enUSToolStripMenuItem.Size = new Size(106, 22);
+            enUSToolStripMenuItem.Size = new Size(180, 22);
             enUSToolStripMenuItem.Text = "en-US";
             enUSToolStripMenuItem.Click += enUSToolStripMenuItem_Click;
             // 
             // frFRToolStripMenuItem
             // 
             frFRToolStripMenuItem.Name = "frFRToolStripMenuItem";
-            frFRToolStripMenuItem.Size = new Size(106, 22);
+            frFRToolStripMenuItem.Size = new Size(180, 22);
             frFRToolStripMenuItem.Text = "fr-FR";
             frFRToolStripMenuItem.Click += frFRToolStripMenuItem_Click;
             // 
@@ -178,7 +178,7 @@
         private Label labelLogs;
         private MenuStrip menuStrip1;
         private ToolStripMenuItem optionsToolStripMenuItem;
-        private ToolStripMenuItem langageToolStripMenuItem;
+        private ToolStripMenuItem languageToolStripMenuItem;
         private ToolStripMenuItem enUSToolStripMenuItem;
         private ToolStripMenuItem frFRToolStripMenuItem;
         private Label label1;

--- a/AccountTester/MainForm.cs
+++ b/AccountTester/MainForm.cs
@@ -149,8 +149,7 @@ namespace AccountTester
 
             try
             {
-                string registryPath = @"SOFTWARE\Microsoft\Office\ClickToRun\Inventory\Office\16.0";
-                using RegistryKey? key = Registry.LocalMachine.OpenSubKey(registryPath);
+                using RegistryKey? key = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Microsoft\Office\ClickToRun\Inventory\Office\16.0");
                 string? officeVersion = key?.GetValue("OfficeProductReleaseIds")?.ToString();
 
                 if (!string.IsNullOrEmpty(officeVersion))
@@ -175,6 +174,15 @@ namespace AccountTester
                 {
                     richTextBoxLogs.AppendText($"- {T("MainForm_RTBL_OfficeVersionTesting_NotFound")}" + Environment.NewLine);
                 }
+
+                // Get Office path
+                ExportVariables.OfficeVersion_export_OfficePath = GetRegValue(@"SOFTWARE\Microsoft\Office\ClickToRun\Configuration", "InstallationPath");
+                // Get Office Culture
+                ExportVariables.OfficeVersion_export_OfficeCulture = GetRegValue(@"SOFTWARE\Microsoft\Office\ClickToRun\Inventory\Office\16.0", "OfficeCulture");
+                // Get Office Excluded Apps
+                ExportVariables.OfficeVersion_export_OfficeExcludedApps = GetRegValue(@"SOFTWARE\Microsoft\Office\ClickToRun\Inventory\Office\16.0", "OfficeExcludedApps");
+                // Get Office Last Update Status
+                ExportVariables.OfficeVersion_export_OfficeLastUpdateStatus = GetRegValue(@"SOFTWARE\Microsoft\Office\ClickToRun\UpdateStatus", "LastUpdateResult");
             }
             catch (Exception ex)
             {
@@ -183,6 +191,16 @@ namespace AccountTester
 
             stopwatch.Stop();
             ExportVariables.OfficeVersion_export_ElapsedTime = stopwatch.ElapsedMilliseconds.ToString();
+        }
+
+        private string GetRegValue(string path, string value)
+        {
+            using RegistryKey? regKey = Registry.LocalMachine.OpenSubKey(path);
+            string? str = regKey?.GetValue(value)?.ToString();
+            if (string.IsNullOrEmpty(str))
+                return "Null";
+            else
+                return str;
         }
 
         /// <summary>                                      
@@ -359,7 +377,7 @@ namespace AccountTester
                         else
                         {
                             richTextBoxLogs.AppendText(printer + Environment.NewLine);
-                            richTextBoxLogs.AppendText($"- {T("MainForm_RTBL_PrinterTesting_NoRegKey")}" + Environment.NewLine);
+                            richTextBoxLogs.AppendText($"- {T("MainForm_RTBL_NoRegKey")}" + Environment.NewLine);
                         }
                     }
                 }

--- a/AccountTester/MainForm.cs
+++ b/AccountTester/MainForm.cs
@@ -29,7 +29,7 @@ namespace AccountTester
             buttonExportForm.Text = T("Export");
             buttonStart.Text = T("Start");
             optionsToolStripMenuItem.Text = T("Options");
-            langageToolStripMenuItem.Text = T("Langage");
+            languageToolStripMenuItem.Text = T("Language");
         }
 
         /// <summary>
@@ -315,10 +315,15 @@ namespace AccountTester
                         using RegistryKey? printerKey = Registry.LocalMachine.OpenSubKey(registryPath);
                         if (printerKey != null)
                         {
+                            ExportVariables.Printer_export_PrinterName = ExportVariables.Printer_export_PrinterName.Append(printer).ToArray();
+                            ExportVariables.Printer_export_PrinterDriver = ExportVariables.Printer_export_PrinterDriver.Append(printerKey.GetValue("Printer Driver").ToString()).ToArray();
+                            ExportVariables.Printer_export_PrinterPort = ExportVariables.Printer_export_PrinterPort.Append(printerKey.GetValue("Port").ToString()).ToArray();
+
                             string? locationValue = printerKey.GetValue("Location")?.ToString();
                             if (!string.IsNullOrEmpty(locationValue))
                             {
                                 string PrinterIP = locationValue.Split("//").Last().Split(":").First();
+                                ExportVariables.Printer_export_PrinterIP = ExportVariables.Printer_export_PrinterIP.Append(PrinterIP).ToArray();
 
                                 if (!string.IsNullOrEmpty(PrinterIP))
                                 {
@@ -329,12 +334,14 @@ namespace AccountTester
                                     {
                                         richTextBoxLogs.AppendText(printer + Environment.NewLine);
                                         richTextBoxLogs.AppendText("- IP : " + PrinterIP + Environment.NewLine + "- Ping : OK" + Environment.NewLine);
+                                        ExportVariables.Printer_export_PrinterStatus = ExportVariables.Printer_export_PrinterStatus.Append("OK").ToArray();
                                         ExportVariables.General_export_TotalSuccess++;
                                     }
                                     else
                                     {
                                         richTextBoxLogs.AppendText(printer + Environment.NewLine);
                                         richTextBoxLogs.AppendText("- IP : " + PrinterIP + Environment.NewLine + "- Ping : FAIL" + Environment.NewLine);
+                                        ExportVariables.Printer_export_PrinterStatus = ExportVariables.Printer_export_PrinterStatus.Append("FAIL").ToArray();
                                     }
                                 }
                                 else
@@ -432,8 +439,6 @@ namespace AccountTester
                 stopwatch.Stop();
                 richTextBoxLogs.AppendText($"- {T("TotalTimeElapsed")} : " + stopwatch.ElapsedMilliseconds + " ms" + Environment.NewLine);
                 richTextBoxLogs.AppendText($"- {T("TotalSuccess")} : {ExportVariables.General_export_TotalSuccess}/{ExportVariables.General_export_TotalTests}");
-                ExportVariables.General_export_TotalSuccess = 0;
-                ExportVariables.General_export_TotalTests = 0;
 
                 System.Media.SoundPlayer player = new(@"C:\Windows\Media\Windows Message Nudge.wav");
                 player.Play();

--- a/AccountTester/strings.Designer.cs
+++ b/AccountTester/strings.Designer.cs
@@ -259,6 +259,15 @@ namespace AccountTester {
         }
         
         /// <summary>
+        ///   Recherche une chaîne localisée semblable à IP.
+        /// </summary>
+        internal static string IP {
+            get {
+                return ResourceManager.GetString("IP", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Recherche une chaîne localisée semblable à Key.
         /// </summary>
         internal static string Key {
@@ -268,11 +277,11 @@ namespace AccountTester {
         }
         
         /// <summary>
-        ///   Recherche une chaîne localisée semblable à Langage.
+        ///   Recherche une chaîne localisée semblable à Language.
         /// </summary>
-        internal static string Langage {
+        internal static string Language {
             get {
-                return ResourceManager.GetString("Langage", resourceCulture);
+                return ResourceManager.GetString("Language", resourceCulture);
             }
         }
         
@@ -642,6 +651,15 @@ namespace AccountTester {
         internal static string TestsFinished {
             get {
                 return ResourceManager.GetString("TestsFinished", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Recherche une chaîne localisée semblable à Title.
+        /// </summary>
+        internal static string Title {
+            get {
+                return ResourceManager.GetString("Title", resourceCulture);
             }
         }
         

--- a/AccountTester/strings.Designer.cs
+++ b/AccountTester/strings.Designer.cs
@@ -169,6 +169,15 @@ namespace AccountTester {
         }
         
         /// <summary>
+        ///   Recherche une chaîne localisée semblable à Excluded Apps.
+        /// </summary>
+        internal static string ExcludedApps {
+            get {
+                return ResourceManager.GetString("ExcludedApps", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Recherche une chaîne localisée semblable à Export.
         /// </summary>
         internal static string Export {
@@ -286,6 +295,15 @@ namespace AccountTester {
         }
         
         /// <summary>
+        ///   Recherche une chaîne localisée semblable à Last Update Status.
+        /// </summary>
+        internal static string LastUpdateStatus {
+            get {
+                return ResourceManager.GetString("LastUpdateStatus", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Recherche une chaîne localisée semblable à Letter.
         /// </summary>
         internal static string Letter {
@@ -349,6 +367,15 @@ namespace AccountTester {
         }
         
         /// <summary>
+        ///   Recherche une chaîne localisée semblable à Registry key not found..
+        /// </summary>
+        internal static string MainForm_RTBL_NoRegKey {
+            get {
+                return ResourceManager.GetString("MainForm_RTBL_NoRegKey", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Recherche une chaîne localisée semblable à Version not found.
         /// </summary>
         internal static string MainForm_RTBL_OfficeVersionTesting_NotFound {
@@ -363,15 +390,6 @@ namespace AccountTester {
         internal static string MainForm_RTBL_PrinterTesting_NoLocationValueReg {
             get {
                 return ResourceManager.GetString("MainForm_RTBL_PrinterTesting_NoLocationValueReg", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Recherche une chaîne localisée semblable à Registry key not found for printer..
-        /// </summary>
-        internal static string MainForm_RTBL_PrinterTesting_NoRegKey {
-            get {
-                return ResourceManager.GetString("MainForm_RTBL_PrinterTesting_NoRegKey", resourceCulture);
             }
         }
         

--- a/AccountTester/strings.fr.resx
+++ b/AccountTester/strings.fr.resx
@@ -168,8 +168,8 @@
   <data name="MainForm_RTBL_PrinterTesting_NoLocationValueReg" xml:space="preserve">
     <value>Emplacement non trouvé dans le registre.</value>
   </data>
-  <data name="MainForm_RTBL_PrinterTesting_NoRegKey" xml:space="preserve">
-    <value>Clé de registre non trouvée pour l'imprimante.</value>
+  <data name="MainForm_RTBL_NoRegKey" xml:space="preserve">
+    <value>Clé de registre non trouvée.</value>
   </data>
   <data name="Start" xml:space="preserve">
     <value>Démarrer</value>
@@ -338,5 +338,14 @@
   </data>
   <data name="IP" xml:space="preserve">
     <value>IP</value>
+  </data>
+  <data name="Culture" xml:space="preserve">
+    <value>Culture</value>
+  </data>
+  <data name="ExcludedApps" xml:space="preserve">
+    <value>Applications exclues</value>
+  </data>
+  <data name="LastUpdateStatus" xml:space="preserve">
+    <value>Status dernière mise à jour</value>
   </data>
 </root>

--- a/AccountTester/strings.fr.resx
+++ b/AccountTester/strings.fr.resx
@@ -174,7 +174,7 @@
   <data name="Start" xml:space="preserve">
     <value>Démarrer</value>
   </data>
-  <data name="Langage" xml:space="preserve">
+  <data name="Language" xml:space="preserve">
     <value>Langue</value>
   </data>
   <data name="Options" xml:space="preserve">
@@ -332,5 +332,11 @@
   </data>
   <data name="Extension" xml:space="preserve">
     <value>Extension</value>
+  </data>
+  <data name="Title" xml:space="preserve">
+    <value>Titre</value>
+  </data>
+  <data name="IP" xml:space="preserve">
+    <value>IP</value>
   </data>
 </root>

--- a/AccountTester/strings.resx
+++ b/AccountTester/strings.resx
@@ -174,8 +174,8 @@
   <data name="Start" xml:space="preserve">
     <value>Start</value>
   </data>
-  <data name="Langage" xml:space="preserve">
-    <value>Langage</value>
+  <data name="Language" xml:space="preserve">
+    <value>Language</value>
   </data>
   <data name="Options" xml:space="preserve">
     <value>Options</value>
@@ -332,5 +332,11 @@
   </data>
   <data name="Extension" xml:space="preserve">
     <value>Extension</value>
+  </data>
+  <data name="Title" xml:space="preserve">
+    <value>Title</value>
+  </data>
+  <data name="IP" xml:space="preserve">
+    <value>IP</value>
   </data>
 </root>

--- a/AccountTester/strings.resx
+++ b/AccountTester/strings.resx
@@ -168,8 +168,8 @@
   <data name="MainForm_RTBL_PrinterTesting_NoLocationValueReg" xml:space="preserve">
     <value>Location value not found in registry.</value>
   </data>
-  <data name="MainForm_RTBL_PrinterTesting_NoRegKey" xml:space="preserve">
-    <value>Registry key not found for printer.</value>
+  <data name="MainForm_RTBL_NoRegKey" xml:space="preserve">
+    <value>Registry key not found.</value>
   </data>
   <data name="Start" xml:space="preserve">
     <value>Start</value>
@@ -338,5 +338,14 @@
   </data>
   <data name="IP" xml:space="preserve">
     <value>IP</value>
+  </data>
+  <data name="Culture" xml:space="preserve">
+    <value>Culture</value>
+  </data>
+  <data name="ExcludedApps" xml:space="preserve">
+    <value>Excluded Apps</value>
+  </data>
+  <data name="LastUpdateStatus" xml:space="preserve">
+    <value>Last Update Status</value>
   </data>
 </root>


### PR DESCRIPTION
## Purpose :
- Fix #34 
- #27 

## Details :
- Refonte de l'export en `.json` pour inclure les traduction des nom d'objet. Mise en place de bloc plus granulaire avec utilisation d'un `Dictionary<string, object>` plutôt qu'un objet anonyme.
- Modifications apportées à `ExportForm.cs` pour passer à une structure d'exportation plus détaillée des informations sur les imprimantes, incluant le nom, l'IP, le statut, le pilote et le port.
- Mise à jour des variables dans `ExportVariables.cs` pour utiliser des tableaux au lieu de types nullable, avec des valeurs par défaut définies.
- Correction des erreurs de nommage dans `MainForm.Designer.cs` et `MainForm.cs`, en remplaçant "langage" par "language" pour une meilleure cohérence linguistique.
- Ajouts de nouvelles chaînes localisées dans `strings.Designer.cs` et les fichiers `.resx`, incluant "IP" et "Title", et correction des incohérences de traduction.
- Ajustements dans la logique de traitement des imprimantes pour garantir la collecte et le stockage corrects des informations.
- Mise à jour de `ExportForm.cs` pour gérer les versions d'Office, avec affichage des versions séparées et ajout d'informations sur la culture, les applications exclues et le statut de la dernière mise à jour.
- Ajout de nouvelles variables dans `ExportVariables.cs` pour stocker ces informations.
- Modification de `LangManager.cs` pour inclure des méthodes de traduction et de gestion de la langue, ainsi que des fonctions pour retirer les diacritiques.
- Mise à jour de `MainForm.cs` pour récupérer des informations supplémentaires sur Office à partir du registre Windows.
- Actualisation des fichiers de ressources `strings.Designer.cs`, `strings.fr.resx` et `strings.resx` pour inclure de nouvelles chaînes localisées et améliorer la clarté des chaînes existantes.