### PR TITLE
Refactorisation des variables et mise à jour des chaînes

### DIFF
--- a/AccountTester/ExportForm.cs
+++ b/AccountTester/ExportForm.cs
@@ -108,33 +108,32 @@ namespace AccountTester
             using StreamWriter sw = new(path);
             sw.WriteLine(fileName);
             sw.WriteLine($"{T("Date")}: {ExportVariables.General_DateAndHour}");
-            sw.WriteLine($"{T("Username")}: {ExportVariables.General_export_UserName}\n\n");
+            sw.WriteLine($"{T("Username")}: {ExportVariables.General_UserName}\n\n");
 
             sw.WriteLine(T("General"));
             sw.WriteLine("-----------------------------------");
-            sw.WriteLine($"{T("OperatingSystem")}: {ExportVariables.General_export_DeviceOS}");
-            sw.WriteLine($"{T("OSArchitecture")}: {ExportVariables.General_export_OSArchitecture}\n\n");
+            sw.WriteLine($"{T("OperatingSystem")}: {ExportVariables.General_DeviceOS}");
+            sw.WriteLine($"{T("OSArchitecture")}: {ExportVariables.General_OSArchitecture}\n\n");
 
             sw.WriteLine(T("InternetConnexion"));
             sw.WriteLine("-----------------------------------");
-            sw.WriteLine($"{T("Hour")}: {ExportVariables.InternetConnexion_export_Hour}");
-            sw.WriteLine($"{T("TestedURL")}: {ExportVariables.InternetConnexion_export_TestedURL}");
-            sw.WriteLine($"{T("HTMLStatus")}: {ExportVariables.InternetConnexion_export_HTMLStatut}");
-            sw.WriteLine($"{T("ResponseTime")}: {ExportVariables.InternetConnexion_export_ElapsedTime} ms\n\n");
+            sw.WriteLine($"{T("Hour")}: {ExportVariables.InternetConnexion_Hour}");
+            sw.WriteLine($"{T("TestedURL")}: {ExportVariables.InternetConnexion_TestedURL}");
+            sw.WriteLine($"{T("HTMLStatus")}: {ExportVariables.InternetConnexion_HTMLStatut}");
+            sw.WriteLine($"{T("ResponseTime")}: {ExportVariables.InternetConnexion_ElapsedTime} ms\n\n");
 
             sw.WriteLine(T("NetworkStorageRights"));
             sw.WriteLine("-----------------------------------");
-            sw.WriteLine($"{T("Hour")}: {ExportVariables.NetworkStorageRights_export_Hour}");
-            sw.WriteLine($"{T("ConnexionType")} : {ExportVariables.NetworkStorageRights_export_ConnexionType}");
+            sw.WriteLine($"{T("Hour")}: {ExportVariables.NetworkStorageRights_Hour}");
             sw.WriteLine($"{T("Disk")}:");
-            if (ExportVariables.NetworkStorageRights_export_DiskLetter != null)
+            if (ExportVariables.NetworkStorageRights_DiskLetter != null)
             {
-                foreach (string diskLetter in ExportVariables.NetworkStorageRights_export_DiskLetter)
+                foreach (string diskLetter in ExportVariables.NetworkStorageRights_DiskLetter)
                 {
                     sw.WriteLine($"{T("Letter")}: {diskLetter}");
-                    sw.WriteLine($"{T("UNCPath")}: {ExportVariables.NetworkStorageRights_export_CheminUNC?[i]}");
-                    sw.WriteLine($"{T("Server")}: {ExportVariables.NetworkStorageRights_export_Serveur?[i]}");
-                    sw.WriteLine($"{T("ShareName")}: {ExportVariables.NetworkStorageRights_export_ShareName?[i]}");
+                    sw.WriteLine($"{T("UNCPath")}: {ExportVariables.NetworkStorageRights_CheminUNC?[i]}");
+                    sw.WriteLine($"{T("Server")}: {ExportVariables.NetworkStorageRights_Serveur?[i]}");
+                    sw.WriteLine($"{T("ShareName")}: {ExportVariables.NetworkStorageRights_ShareName?[i]}");
                     i++;
                 }
             }
@@ -142,54 +141,54 @@ namespace AccountTester
             {
                 sw.WriteLine(T("NoNetworkShare"));
             }
-            sw.WriteLine($"{T("ElapsedTime")}: {ExportVariables.NetworkStorageRights_export_ElapsedTime} ms\n\n");
+            sw.WriteLine($"{T("ElapsedTime")}: {ExportVariables.NetworkStorageRights_ElapsedTime} ms\n\n");
             i = 0;
 
             sw.WriteLine("Office");
             sw.WriteLine("-----------------------------------");
-            sw.WriteLine($"{T("Hour")}: {ExportVariables.OfficeVersion_export_Hour}");
-            if (ExportVariables.OfficeVersion_export_OfficeVersion.Split(',').Length > 0)
+            sw.WriteLine($"{T("Hour")}: {ExportVariables.OfficeVersion_Hour}");
+            if (ExportVariables.OfficeVersion_OfficeVersion.Split(',').Length > 0)
             {
                 sw.WriteLine($"{T("OfficeVersion")}:");
-                foreach (string version in ExportVariables.OfficeVersion_export_OfficeVersion.Split(','))
+                foreach (string version in ExportVariables.OfficeVersion_OfficeVersion.Split(','))
                 {
                     sw.WriteLine($"- {version}");
                 }
-                sw.WriteLine($"{T("Path")}: {ExportVariables.OfficeVersion_export_OfficePath}");
-                sw.WriteLine($"{T("Culture")}: {ExportVariables.OfficeVersion_export_OfficeCulture}");
-                sw.WriteLine($"{T("ExcludedApps")}: {ExportVariables.OfficeVersion_export_OfficeExcludedApps}");
-                sw.WriteLine($"{T("LastUpdateStatus")}: {ExportVariables.OfficeVersion_export_OfficeLastUpdateStatus}");
+                sw.WriteLine($"{T("Path")}: {ExportVariables.OfficeVersion_OfficePath}");
+                sw.WriteLine($"{T("Culture")}: {ExportVariables.OfficeVersion_OfficeCulture}");
+                sw.WriteLine($"{T("ExcludedApps")}: {ExportVariables.OfficeVersion_OfficeExcludedApps}");
+                sw.WriteLine($"{T("LastUpdateStatus")}: {ExportVariables.OfficeVersion_OfficeLastUpdateStatus}");
             }
             else
             {
                 sw.WriteLine(T("MainForm_RTBL_PrinterTesting_NotFound"));
             }
-            sw.WriteLine($"{T("ElapsedTime")}: {ExportVariables.OfficeVersion_export_ElapsedTime} ms\n\n");
+            sw.WriteLine($"{T("ElapsedTime")}: {ExportVariables.OfficeVersion_ElapsedTime} ms\n\n");
 
             sw.WriteLine(T("OfficeRights"));
             sw.WriteLine("-----------------------------------");
-            sw.WriteLine($"{T("Hour")}: {ExportVariables.OfficeRights_export_Hour}");
-            sw.WriteLine($"{T("Write")}: {ExportVariables.OfficeRights_export_Write}");
-            sw.WriteLine($"{T("Read")}: {ExportVariables.OfficeRights_export_Read}");
-            sw.WriteLine($"{T("Delete")}: {ExportVariables.OfficeRights_export_Delete}");
-            sw.WriteLine($"{T("Create")}: {ExportVariables.OfficeRights_export_Create}");
-            sw.WriteLine($"{T("Save")}: {ExportVariables.OfficeRights_export_Save}");
+            sw.WriteLine($"{T("Hour")}: {ExportVariables.OfficeRights_Hour}");
+            sw.WriteLine($"{T("Write")}: {ExportVariables.OfficeRights_Write}");
+            sw.WriteLine($"{T("Read")}: {ExportVariables.OfficeRights_Read}");
+            sw.WriteLine($"{T("Delete")}: {ExportVariables.OfficeRights_Delete}");
+            sw.WriteLine($"{T("Create")}: {ExportVariables.OfficeRights_Create}");
+            sw.WriteLine($"{T("Save")}: {ExportVariables.OfficeRights_Save}");
             sw.WriteLine($"{T("TestedFolder")}: ");
-            sw.WriteLine($"- {ExportVariables.OfficeRights_export_FolderTested}\n");
-            sw.WriteLine($"{T("ElapsedTime")}: {ExportVariables.OfficeRights_export_ElapsedTime} ms\n\n");
+            sw.WriteLine($"- {ExportVariables.OfficeRights_FolderTested}\n");
+            sw.WriteLine($"{T("ElapsedTime")}: {ExportVariables.OfficeRights_ElapsedTime} ms\n\n");
 
             sw.WriteLine(T("Printer"));
             sw.WriteLine("-----------------------------------");
-            sw.WriteLine($"{T("Hour")}: {ExportVariables.Printer_export_Hour}");
-            if (ExportVariables.Printer_export_PrinterName != null)
+            sw.WriteLine($"{T("Hour")}: {ExportVariables.Printer_Hour}");
+            if (ExportVariables.Printer_PrinterName != null)
             {
-                foreach (string printerName in ExportVariables.Printer_export_PrinterName)
+                foreach (string printerName in ExportVariables.Printer_PrinterName)
                 {
                     sw.WriteLine($"{T("Name")}: {printerName}");
-                    sw.WriteLine($"- {T("IP")}: {ExportVariables.Printer_export_PrinterIP?[i]}");
-                    sw.WriteLine($"- {T("Status")}: {ExportVariables.Printer_export_PrinterStatus?[i]}");
-                    sw.WriteLine($"- {T("Driver")}: {ExportVariables.Printer_export_PrinterDriver?[i]}");
-                    sw.WriteLine($"- {T("Port")}: {ExportVariables.Printer_export_PrinterPort?[i]}");
+                    sw.WriteLine($"- {T("IP")}: {ExportVariables.Printer_PrinterIP?[i]}");
+                    sw.WriteLine($"- {T("Status")}: {ExportVariables.Printer_PrinterStatus?[i]}");
+                    sw.WriteLine($"- {T("Driver")}: {ExportVariables.Printer_PrinterDriver?[i]}");
+                    sw.WriteLine($"- {T("Port")}: {ExportVariables.Printer_PrinterPort?[i]}");
                     i++;
                 }
             }
@@ -197,7 +196,7 @@ namespace AccountTester
             {
                 sw.WriteLine(T("NoPrinterFound"));
             }
-            sw.WriteLine($"{T("ElapsedTime")}: {ExportVariables.Printer_export_ElapsedTime} ms\n\n");
+            sw.WriteLine($"{T("ElapsedTime")}: {ExportVariables.Printer_ElapsedTime} ms\n\n");
             i = 0;
 
             sw.Close();
@@ -213,7 +212,7 @@ namespace AccountTester
             string path = Path.Combine(filePath, $"{fileName}.log");
             using StreamWriter sw = new(path);
 
-            sw.Write(ExportVariables.General_export_Resume);
+            sw.Write(ExportVariables.General_Resume);
             sw.Close();
         }
 
@@ -231,67 +230,72 @@ namespace AccountTester
 
             XmlElement general = doc.CreateElement(TT("General"));
             root.AppendChild(general);
-            XMLW(doc, general, TT("OperatingSystem"), ExportVariables.General_export_DeviceOS);
-            XMLW(doc, general, TT("OSArchitecture"), ExportVariables.General_export_OSArchitecture);
-            XMLW(doc, general, TT("Username"), ExportVariables.General_export_UserName);
+            XMLW(doc, general, TT("OperatingSystem"), ExportVariables.General_DeviceOS);
+            XMLW(doc, general, TT("OSArchitecture"), ExportVariables.General_OSArchitecture);
+            XMLW(doc, general, TT("Username"), ExportVariables.General_UserName);
             XMLW(doc, general, TT("Date"), ExportVariables.General_DateAndHour);
-            XMLW(doc, general, TT("TotalTests"), ExportVariables.General_export_TotalTests.ToString());
-            XMLW(doc, general, TT("TotalSuccess"), ExportVariables.General_export_TotalSuccess.ToString());
+            XMLW(doc, general, TT("TotalTests"), ExportVariables.General_TotalTests.ToString());
+            XMLW(doc, general, TT("TotalSuccess"), ExportVariables.General_TotalSuccess.ToString());
 
             XmlElement internetConnection = doc.CreateElement(TT("InternetConnexion"));
             root.AppendChild(internetConnection);
-            XMLW(doc, internetConnection, TT("Hour"), ExportVariables.InternetConnexion_export_Hour);
-            XMLW(doc, internetConnection, TT("TestedURL"), ExportVariables.InternetConnexion_export_TestedURL);
-            XMLW(doc, internetConnection, TT("HTMLStatus"), ExportVariables.InternetConnexion_export_HTMLStatut);
-            XMLW(doc, internetConnection, TT("ResponseTime"), ExportVariables.InternetConnexion_export_ElapsedTime);
+            XMLW(doc, internetConnection, TT("Hour"), ExportVariables.InternetConnexion_Hour);
+            XMLW(doc, internetConnection, TT("TestedURL"), ExportVariables.InternetConnexion_TestedURL);
+            XMLW(doc, internetConnection, TT("HTMLStatus"), ExportVariables.InternetConnexion_HTMLStatut);
+            XMLW(doc, internetConnection, TT("ResponseTime"), ExportVariables.InternetConnexion_ElapsedTime);
 
             XmlElement networkStorageRights = doc.CreateElement(TT("NetworkStorageRights"));
             root.AppendChild(networkStorageRights);
-            XMLW(doc, networkStorageRights, TT("Hour"), ExportVariables.NetworkStorageRights_export_Hour);
-            XMLW(doc, networkStorageRights, TT("ConnexionType"), ExportVariables.NetworkStorageRights_export_ConnexionType);
-            XMLWL(doc, networkStorageRights, TT("DiskLetter"), ExportVariables.NetworkStorageRights_export_DiskLetter, TT("Disk"));
-            XMLWL(doc, networkStorageRights, TT("UNCPath"), ExportVariables.NetworkStorageRights_export_CheminUNC, TT("Path"));
-            XMLWL(doc, networkStorageRights, TT("Server"), ExportVariables.NetworkStorageRights_export_Serveur, TT("ServerName"));
-            XMLWL(doc, networkStorageRights, TT("Share"), ExportVariables.NetworkStorageRights_export_ShareName, TT("ShareName"));
-            XMLW(doc, networkStorageRights, TT("ElapsedTime"), ExportVariables.NetworkStorageRights_export_ElapsedTime);
+            XMLW(doc, networkStorageRights, TT("Hour"), ExportVariables.NetworkStorageRights_Hour);
+            for (int i = 0; i < ExportVariables.NetworkStorageRights_DiskLetter?.Length; i++)
+            {
+                XmlElement disk = doc.CreateElement($"{TT("Disk")}_{i}");
+                networkStorageRights.AppendChild(disk);
+                XMLW(doc, disk, TT("DiskLetter"), ExportVariables.NetworkStorageRights_DiskLetter[i]);
+                XMLW(doc, disk, TT("UNCPath"), ExportVariables.NetworkStorageRights_CheminUNC?[i] ?? string.Empty);
+                XMLW(doc, disk, TT("Server"), ExportVariables.NetworkStorageRights_Serveur?[i] ?? string.Empty);
+                XMLW(doc, disk, TT("ShareName"), ExportVariables.NetworkStorageRights_ShareName?[i] ?? string.Empty);
+            }
+
+            XMLW(doc, networkStorageRights, TT("ElapsedTime"), ExportVariables.NetworkStorageRights_ElapsedTime);
 
             XmlElement officeVersion = doc.CreateElement(TT("OfficeVersion"));
             root.AppendChild(officeVersion);
-            XMLW(doc, officeVersion, TT("Hour"), ExportVariables.OfficeVersion_export_Hour);
-            XMLW(doc, officeVersion, TT("Version"), ExportVariables.OfficeVersion_export_OfficeVersion);
-            XMLW(doc, officeVersion, TT("Path"), ExportVariables.OfficeVersion_export_OfficePath);
-            XMLW(doc, officeVersion, TT("Culture"), ExportVariables.OfficeVersion_export_OfficeCulture);
-            XMLW(doc, officeVersion, TT("ExcludedApps"), ExportVariables.OfficeVersion_export_OfficeExcludedApps);
-            XMLW(doc, officeVersion, TT("LastUpdateStatus"), ExportVariables.OfficeVersion_export_OfficeLastUpdateStatus);
-            XMLW(doc, officeVersion, TT("ElapsedTime"), ExportVariables.OfficeVersion_export_ElapsedTime);
+            XMLW(doc, officeVersion, TT("Hour"), ExportVariables.OfficeVersion_Hour);
+            XMLW(doc, officeVersion, TT("Version"), ExportVariables.OfficeVersion_OfficeVersion);
+            XMLW(doc, officeVersion, TT("Path"), ExportVariables.OfficeVersion_OfficePath);
+            XMLW(doc, officeVersion, TT("Culture"), ExportVariables.OfficeVersion_OfficeCulture);
+            XMLW(doc, officeVersion, TT("ExcludedApps"), ExportVariables.OfficeVersion_OfficeExcludedApps);
+            XMLW(doc, officeVersion, TT("LastUpdateStatus"), ExportVariables.OfficeVersion_OfficeLastUpdateStatus);
+            XMLW(doc, officeVersion, TT("ElapsedTime"), ExportVariables.OfficeVersion_ElapsedTime);
 
             XmlElement officeRights = doc.CreateElement(TT("OfficeRights"));
             root.AppendChild(officeRights);
-            XMLW(doc, officeRights, TT("Hour"), ExportVariables.OfficeRights_export_Hour);
-            XMLW(doc, officeRights, TT("Write"), ExportVariables.OfficeRights_export_Write);
-            XMLW(doc, officeRights, TT("Read"), ExportVariables.OfficeRights_export_Read);
-            XMLW(doc, officeRights, TT("Delete"), ExportVariables.OfficeRights_export_Delete);
-            XMLW(doc, officeRights, TT("Create"), ExportVariables.OfficeRights_export_Create);
-            XMLW(doc, officeRights, TT("Save"), ExportVariables.OfficeRights_export_Save);
-            XMLW(doc, officeRights, TT("TestedFolder"), ExportVariables.OfficeRights_export_FolderTested);
-            XMLW(doc, officeRights, TT("ElapsedTime"), ExportVariables.OfficeRights_export_ElapsedTime);
+            XMLW(doc, officeRights, TT("Hour"), ExportVariables.OfficeRights_Hour);
+            XMLW(doc, officeRights, TT("Write"), ExportVariables.OfficeRights_Write);
+            XMLW(doc, officeRights, TT("Read"), ExportVariables.OfficeRights_Read);
+            XMLW(doc, officeRights, TT("Delete"), ExportVariables.OfficeRights_Delete);
+            XMLW(doc, officeRights, TT("Create"), ExportVariables.OfficeRights_Create);
+            XMLW(doc, officeRights, TT("Save"), ExportVariables.OfficeRights_Save);
+            XMLW(doc, officeRights, TT("TestedFolder"), ExportVariables.OfficeRights_FolderTested);
+            XMLW(doc, officeRights, TT("ElapsedTime"), ExportVariables.OfficeRights_ElapsedTime);
 
             XmlElement printers = doc.CreateElement(TT("Printer"));
             root.AppendChild(printers);
-            XMLW(doc, printers, TT("Hour"), ExportVariables.Printer_export_Hour);
+            XMLW(doc, printers, TT("Hour"), ExportVariables.Printer_Hour);
 
-            for (int i = 0; i < ExportVariables.Printer_export_PrinterName?.Length; i++)
+            for (int i = 0; i < ExportVariables.Printer_PrinterName?.Length; i++)
             {
                 XmlElement printer = doc.CreateElement($"{TT("Printer")}_{i}");
                 printers.AppendChild(printer);
-                XMLW(doc, printer, TT("Name"), ExportVariables.Printer_export_PrinterName[i]);
-                XMLW(doc, printer, TT("IP"), ExportVariables.Printer_export_PrinterIP[i]);
-                XMLW(doc, printer, TT("Status"), ExportVariables.Printer_export_PrinterStatus[i]);
-                XMLW(doc, printer, TT("Driver"), ExportVariables.Printer_export_PrinterDriver[i]);
-                XMLW(doc, printer, TT("Port"), ExportVariables.Printer_export_PrinterPort[i]);
+                XMLW(doc, printer, TT("Name"), ExportVariables.Printer_PrinterName[i]);
+                XMLW(doc, printer, TT("IP"), ExportVariables.Printer_PrinterIP[i]);
+                XMLW(doc, printer, TT("Status"), ExportVariables.Printer_PrinterStatus[i]);
+                XMLW(doc, printer, TT("Driver"), ExportVariables.Printer_PrinterDriver[i]);
+                XMLW(doc, printer, TT("Port"), ExportVariables.Printer_PrinterPort[i]);
             }
 
-            XMLW(doc, printers, TT("ElapsedTime"), ExportVariables.Printer_export_ElapsedTime);
+            XMLW(doc, printers, TT("ElapsedTime"), ExportVariables.Printer_ElapsedTime);
 
             string path = Path.Combine(filePath, $"{fileName}.xml");
             doc.Save(path);
@@ -347,75 +351,74 @@ namespace AccountTester
 
             CSVWL(T("General"), T("ReportName"), fileName, sw);
             CSVWL(T("General"), $"{T("Date")}/{T("Hour")}", ExportVariables.General_DateAndHour, sw);
-            CSVWL(T("General"), T("OperatingSystem"), ExportVariables.General_export_DeviceOS, sw);
-            CSVWL(T("General"), T("OSArchitecture"), ExportVariables.General_export_OSArchitecture, sw);
-            CSVWL(T("General"), T("Username"), ExportVariables.General_export_UserName, sw);
-            CSVWL(T("General"), T("TotalTests"), ExportVariables.General_export_TotalTests.ToString(), sw);
-            CSVWL(T("General"), T("TotalSuccess"), ExportVariables.General_export_TotalSuccess.ToString(), sw);
+            CSVWL(T("General"), T("OperatingSystem"), ExportVariables.General_DeviceOS, sw);
+            CSVWL(T("General"), T("OSArchitecture"), ExportVariables.General_OSArchitecture, sw);
+            CSVWL(T("General"), T("Username"), ExportVariables.General_UserName, sw);
+            CSVWL(T("General"), T("TotalTests"), ExportVariables.General_TotalTests.ToString(), sw);
+            CSVWL(T("General"), T("TotalSuccess"), ExportVariables.General_TotalSuccess.ToString(), sw);
 
-            CSVWL(T("InternetConnexion"), T("Hour"), ExportVariables.InternetConnexion_export_Hour, sw);
-            CSVWL(T("InternetConnexion"), T("TestedURL"), ExportVariables.InternetConnexion_export_TestedURL, sw);
-            CSVWL(T("InternetConnexion"), T("HTMLStatus"), ExportVariables.InternetConnexion_export_HTMLStatut, sw);
-            CSVWL(T("InternetConnexion"), $"{T("ResponseTime")} (ms)", ExportVariables.InternetConnexion_export_ElapsedTime, sw);
-
-            CSVWL(T("NetworkStorageRights"), T("Hour"), ExportVariables.NetworkStorageRights_export_Hour, sw);
-            CSVWL(T("NetworkStorageRights"), T("ConnexionType"), ExportVariables.NetworkStorageRights_export_ConnexionType, sw);
-            if (ExportVariables.NetworkStorageRights_export_DiskLetter != null)
+            CSVWL(T("InternetConnexion"), T("Hour"), ExportVariables.InternetConnexion_Hour, sw);
+            CSVWL(T("InternetConnexion"), T("TestedURL"), ExportVariables.InternetConnexion_TestedURL, sw);
+            CSVWL(T("InternetConnexion"), T("HTMLStatus"), ExportVariables.InternetConnexion_HTMLStatut, sw);
+            CSVWL(T("InternetConnexion"), $"{T("ResponseTime")} (ms)", ExportVariables.InternetConnexion_ElapsedTime, sw);
+            
+            CSVWL(T("NetworkStorageRights"), T("Hour"), ExportVariables.NetworkStorageRights_Hour, sw);
+            if (ExportVariables.NetworkStorageRights_DiskLetter != null)
             {
-                for (int i = 0; i < ExportVariables.NetworkStorageRights_export_DiskLetter.Length; i++)
+                for (int i = 0; i < ExportVariables.NetworkStorageRights_DiskLetter.Length; i++)
                 {
-                    CSVWL(T("NetworkStorageRights"), T("DiskLetter"), ExportVariables.NetworkStorageRights_export_DiskLetter[i], sw);
-                    CSVWL(T("NetworkStorageRights"), T("UNCPath"), ExportVariables.NetworkStorageRights_export_CheminUNC?[i], sw);
-                    CSVWL(T("NetworkStorageRights"), T("Server"), ExportVariables.NetworkStorageRights_export_Serveur?[i], sw);
-                    CSVWL(T("NetworkStorageRights"), T("ShareName"), ExportVariables.NetworkStorageRights_export_ShareName?[i], sw);
+                    CSVWL($"{T("Disk")}_{i}", T("DiskLetter"), ExportVariables.NetworkStorageRights_DiskLetter[i], sw);
+                    CSVWL($"{T("Disk")}_{i}", T("UNCPath"), ExportVariables.NetworkStorageRights_CheminUNC[i], sw);
+                    CSVWL($"{T("Disk")}_{i}", T("Server"), ExportVariables.NetworkStorageRights_Serveur[i], sw);
+                    CSVWL($"{T("Disk")}_{i}", T("ShareName"), ExportVariables.NetworkStorageRights_ShareName[i], sw);
                 }
             }
             else
             {
                 CSVWL(T("NetworkStorageRights"), T("NoNetworkShare"), "", sw);
             }
-            CSVWL(T("NetworkStorageRights"), $"{T("ElapsedTime")} (ms)", ExportVariables.NetworkStorageRights_export_ElapsedTime, sw);
+            CSVWL(T("NetworkStorageRights"), $"{T("ElapsedTime")} (ms)", ExportVariables.NetworkStorageRights_ElapsedTime, sw);
 
-            CSVWL(T("OfficeVersion"), T("Hour"), ExportVariables.OfficeVersion_export_Hour, sw);
-            if (ExportVariables.OfficeVersion_export_OfficeVersion.Split(',').Length > 0)
+            CSVWL(T("OfficeVersion"), T("Hour"), ExportVariables.OfficeVersion_Hour, sw);
+            if (ExportVariables.OfficeVersion_OfficeVersion.Split(',').Length > 0)
             {
-                foreach (string version in ExportVariables.OfficeVersion_export_OfficeVersion.Split(','))
+                foreach (string version in ExportVariables.OfficeVersion_OfficeVersion.Split(','))
                 {
                     CSVWL(T("OfficeVersion"), T("Version"), version, sw);
                 }
             }
-            CSVWL(T("OfficeVersion"), T("OfficePath"), ExportVariables.OfficeVersion_export_OfficePath, sw);
-            CSVWL(T("OfficeVersion"), T("Culture"), ExportVariables.OfficeVersion_export_OfficeCulture, sw);
-            CSVWL(T("OfficeVersion"), T("ExcludedApps"), ExportVariables.OfficeVersion_export_OfficeExcludedApps.Replace(",", " "), sw);
-            CSVWL(T("OfficeVersion"), T("LastUpdateStatus"), ExportVariables.OfficeVersion_export_OfficeLastUpdateStatus, sw);
-            CSVWL(T("OfficeVersion"), $"{T("ElapsedTime")} (ms)", ExportVariables.OfficeVersion_export_ElapsedTime, sw);
+            CSVWL(T("OfficeVersion"), T("OfficePath"), ExportVariables.OfficeVersion_OfficePath, sw);
+            CSVWL(T("OfficeVersion"), T("Culture"), ExportVariables.OfficeVersion_OfficeCulture, sw);
+            CSVWL(T("OfficeVersion"), T("ExcludedApps"), ExportVariables.OfficeVersion_OfficeExcludedApps.Replace(",", " "), sw);
+            CSVWL(T("OfficeVersion"), T("LastUpdateStatus"), ExportVariables.OfficeVersion_OfficeLastUpdateStatus, sw);
+            CSVWL(T("OfficeVersion"), $"{T("ElapsedTime")} (ms)", ExportVariables.OfficeVersion_ElapsedTime, sw);
 
-            CSVWL(T("OfficeRights"), T("Hour"), ExportVariables.OfficeRights_export_Hour, sw);
-            CSVWL(T("OfficeRights"), T("Write"), ExportVariables.OfficeRights_export_Write, sw);
-            CSVWL(T("OfficeRights"), T("Read"), ExportVariables.OfficeRights_export_Read, sw);
-            CSVWL(T("OfficeRights"), T("Delete"), ExportVariables.OfficeRights_export_Delete, sw);
-            CSVWL(T("OfficeRights"), T("Create"), ExportVariables.OfficeRights_export_Create, sw);
-            CSVWL(T("OfficeRights"), T("Save"), ExportVariables.OfficeRights_export_Save, sw);
-            CSVWL(T("OfficeRights"), T("TestedFolder"), ExportVariables.OfficeRights_export_FolderTested, sw);
-            CSVWL(T("OfficeRights"), $"{T("ElapsedTime")} (ms)", ExportVariables.OfficeRights_export_ElapsedTime, sw);
+            CSVWL(T("OfficeRights"), T("Hour"), ExportVariables.OfficeRights_Hour, sw);
+            CSVWL(T("OfficeRights"), T("Write"), ExportVariables.OfficeRights_Write, sw);
+            CSVWL(T("OfficeRights"), T("Read"), ExportVariables.OfficeRights_Read, sw);
+            CSVWL(T("OfficeRights"), T("Delete"), ExportVariables.OfficeRights_Delete, sw);
+            CSVWL(T("OfficeRights"), T("Create"), ExportVariables.OfficeRights_Create, sw);
+            CSVWL(T("OfficeRights"), T("Save"), ExportVariables.OfficeRights_Save, sw);
+            CSVWL(T("OfficeRights"), T("TestedFolder"), ExportVariables.OfficeRights_FolderTested, sw);
+            CSVWL(T("OfficeRights"), $"{T("ElapsedTime")} (ms)", ExportVariables.OfficeRights_ElapsedTime, sw);
 
-            CSVWL(T("Printer"), T("Hour"), ExportVariables.Printer_export_Hour, sw);
-            if (ExportVariables.Printer_export_PrinterName != null)
+            CSVWL(T("Printer"), T("Hour"), ExportVariables.Printer_Hour, sw);
+            if (ExportVariables.Printer_PrinterName != null)
             {
-                for (int i = 0; i < ExportVariables.Printer_export_PrinterName.Length; i++)
+                for (int i = 0; i < ExportVariables.Printer_PrinterName.Length; i++)
                 {
-                    CSVWL($"{T("Printer")}_{i}", T("Name"), ExportVariables.Printer_export_PrinterName[i], sw);
-                    CSVWL($"{T("Printer")}_{i}", T("Status"), ExportVariables.Printer_export_PrinterStatus?[i], sw);
-                    CSVWL($"{T("Printer")}_{i}", T("IP"), ExportVariables.Printer_export_PrinterIP?[i], sw);
-                    CSVWL($"{T("Printer")}_{i}", T("Driver"), ExportVariables.Printer_export_PrinterDriver?[i], sw);
-                    CSVWL($"{T("Printer")}_{i}", T("Port"), ExportVariables.Printer_export_PrinterPort?[i], sw);
+                    CSVWL($"{T("Printer")}_{i}", T("Name"), ExportVariables.Printer_PrinterName[i], sw);
+                    CSVWL($"{T("Printer")}_{i}", T("Status"), ExportVariables.Printer_PrinterStatus[i], sw);
+                    CSVWL($"{T("Printer")}_{i}", T("IP"), ExportVariables.Printer_PrinterIP[i], sw);
+                    CSVWL($"{T("Printer")}_{i}", T("Driver"), ExportVariables.Printer_PrinterDriver[i], sw);
+                    CSVWL($"{T("Printer")}_{i}", T("Port"), ExportVariables.Printer_PrinterPort[i], sw);
                 }
             }
             else
             {
                 CSVWL(T("Printer"), T("NoPrinterFound"), "", sw);
             }
-            CSVWL(T("Printer"), $"{T("ElapsedTime")} (ms)", ExportVariables.Printer_export_ElapsedTime, sw);
+            CSVWL(T("Printer"), $"{T("ElapsedTime")} (ms)", ExportVariables.Printer_ElapsedTime, sw);
 
             sw.Close();
         }
@@ -439,81 +442,89 @@ namespace AccountTester
         {
             var Printers = new Dictionary<string, object>
             {
-                [TT("Hour")] = ExportVariables.Printer_export_Hour,
+                [TT("Hour")] = ExportVariables.Printer_Hour,
             };
 
-            int printerCount = ExportVariables.Printer_export_PrinterName?.Length ?? 0;
+            int printerCount = ExportVariables.Printer_PrinterName?.Length ?? 0;
             for (int i = 0; i < printerCount; i++)
             {
                 var printer = new Dictionary<string, object>
                 {
-                    [TT("Name")] = ExportVariables.Printer_export_PrinterName[i],
-                    [TT("IP")] = ExportVariables.Printer_export_PrinterIP[i],
-                    [TT("Status")] = ExportVariables.Printer_export_PrinterStatus[i],
-                    [TT("Driver")] = ExportVariables.Printer_export_PrinterDriver[i],
-                    [TT("Port")] = ExportVariables.Printer_export_PrinterPort[i]
+                    [TT("Name")] = ExportVariables.Printer_PrinterName[i],
+                    [TT("IP")] = ExportVariables.Printer_PrinterIP[i],
+                    [TT("Status")] = ExportVariables.Printer_PrinterStatus[i],
+                    [TT("Driver")] = ExportVariables.Printer_PrinterDriver[i],
+                    [TT("Port")] = ExportVariables.Printer_PrinterPort[i]
                 };
 
                 Printers[$"{TT("Printer")}_{i + 1}"] = printer;
             }
-            Printers[TT("ElapsedTime")] = ExportVariables.Printer_export_ElapsedTime;
+            Printers[TT("ElapsedTime")] = ExportVariables.Printer_ElapsedTime;
 
             var OfficeRights = new Dictionary<string, object>
             {
-                [TT("Hour")] = ExportVariables.OfficeRights_export_Hour,
-                [TT("Write")] = ExportVariables.OfficeRights_export_Write,
-                [TT("Read")] = ExportVariables.OfficeRights_export_Read,
-                [TT("Delete")] = ExportVariables.OfficeRights_export_Delete,
-                [TT("Create")] = ExportVariables.OfficeRights_export_Create,
-                [TT("Save")] = ExportVariables.OfficeRights_export_Save,
-                [TT("TestedFolder")] = ExportVariables.OfficeRights_export_FolderTested,
-                [TT("ElapsedTime")] = ExportVariables.OfficeRights_export_ElapsedTime
+                [TT("Hour")] = ExportVariables.OfficeRights_Hour,
+                [TT("Write")] = ExportVariables.OfficeRights_Write,
+                [TT("Read")] = ExportVariables.OfficeRights_Read,
+                [TT("Delete")] = ExportVariables.OfficeRights_Delete,
+                [TT("Create")] = ExportVariables.OfficeRights_Create,
+                [TT("Save")] = ExportVariables.OfficeRights_Save,
+                [TT("TestedFolder")] = ExportVariables.OfficeRights_FolderTested,
+                [TT("ElapsedTime")] = ExportVariables.OfficeRights_ElapsedTime
             };
 
             var OfficeVersion = new Dictionary<string, object>
             {
-                [TT("Hour")] = ExportVariables.OfficeVersion_export_Hour,
-                [TT("OfficeVersion")] = ExportVariables.OfficeVersion_export_OfficeVersion,
-                [TT("Path")] = ExportVariables.OfficeVersion_export_OfficePath,
-                [TT("Culture")] = ExportVariables.OfficeVersion_export_OfficeCulture,
-                [TT("ExcludedApps")] = ExportVariables.OfficeVersion_export_OfficeExcludedApps,
-                [TT("LastUpdateStatus")] = ExportVariables.OfficeVersion_export_OfficeLastUpdateStatus,
-                [TT("ElapsedTime")] = ExportVariables.OfficeVersion_export_ElapsedTime
+                [TT("Hour")] = ExportVariables.OfficeVersion_Hour,
+                [TT("OfficeVersion")] = ExportVariables.OfficeVersion_OfficeVersion,
+                [TT("Path")] = ExportVariables.OfficeVersion_OfficePath,
+                [TT("Culture")] = ExportVariables.OfficeVersion_OfficeCulture,
+                [TT("ExcludedApps")] = ExportVariables.OfficeVersion_OfficeExcludedApps,
+                [TT("LastUpdateStatus")] = ExportVariables.OfficeVersion_OfficeLastUpdateStatus,
+                [TT("ElapsedTime")] = ExportVariables.OfficeVersion_ElapsedTime
             };
-
 
             var NetworkStorageRights = new Dictionary<string, object>
             {
-                [TT("Hour")] = ExportVariables.NetworkStorageRights_export_Hour,
-                [TT("ConnexionType")] = ExportVariables.NetworkStorageRights_export_ConnexionType,
-                [TT("DiskLetter")] = ExportVariables.NetworkStorageRights_export_DiskLetter,
-                [TT("UNCPath")] = ExportVariables.NetworkStorageRights_export_CheminUNC,
-                [T("Server")] = ExportVariables.NetworkStorageRights_export_Serveur,
-                [TT("ShareName")] = ExportVariables.NetworkStorageRights_export_ShareName,
-                [TT("ElapsedTime")] = ExportVariables.NetworkStorageRights_export_ElapsedTime
+                [TT("Hour")] = ExportVariables.NetworkStorageRights_Hour,
             };
+
+            int drivesCount = ExportVariables.NetworkStorageRights_DiskLetter?.Length ?? 0;
+            for (int i = 0; i < drivesCount; i++)
+            {
+                var Disk = new Dictionary<string, object>
+                {
+                    [TT("DiskLetter")] = ExportVariables.NetworkStorageRights_DiskLetter[i],
+                    [TT("UNCPath")] = ExportVariables.NetworkStorageRights_CheminUNC[i],
+                    [T("Server")] = ExportVariables.NetworkStorageRights_Serveur[i],
+                    [TT("ShareName")] = ExportVariables.NetworkStorageRights_ShareName[i]
+                };
+
+                NetworkStorageRights[$"{TT("Disk")}_{i + 1}"] = Disk;
+            }
+            NetworkStorageRights[TT("ElapsedTime")] = ExportVariables.NetworkStorageRights_ElapsedTime;
 
             var InternetConnexion = new Dictionary<string, object>
             {
-                [TT("Hour")] = ExportVariables.InternetConnexion_export_Hour,
-                [TT("TestedURL")] = ExportVariables.InternetConnexion_export_TestedURL,
-                [TT("HTMLStatus")] = ExportVariables.InternetConnexion_export_HTMLStatut,
-                [TT("ResponseTime")] = ExportVariables.InternetConnexion_export_ElapsedTime
+                [TT("Hour")] = ExportVariables.InternetConnexion_Hour,
+                [TT("TestedURL")] = ExportVariables.InternetConnexion_TestedURL,
+                [TT("HTMLStatus")] = ExportVariables.InternetConnexion_HTMLStatut,
+                [TT("ResponseTime")] = ExportVariables.InternetConnexion_ElapsedTime
             };
 
             var General = new Dictionary<string, object>
             {
-                [TT("OperatingSystem")] = ExportVariables.General_export_DeviceOS,
-                [TT("OSArchitecture")] = ExportVariables.General_export_OSArchitecture,
-                [TT("TotalTests")] = ExportVariables.General_export_TotalTests,
-                [TT("TotalSuccess")] = ExportVariables.General_export_TotalSuccess,
+                [TT("OperatingSystem")] = ExportVariables.General_DeviceOS,
+                [TT("OSArchitecture")] = ExportVariables.General_OSArchitecture,
+                [TT("TotalTests")] = ExportVariables.General_TotalTests,
+                [TT("TotalSuccess")] = ExportVariables.General_TotalSuccess,
             };
 
             var block = new Dictionary<string, object>
             {
                 [TT("Title")] = fileName,
                 [TT("Date")] = ExportVariables.General_DateAndHour,
-                [TT("Username")] = ExportVariables.General_export_UserName,
+                [TT("Username")] = ExportVariables.General_UserName,
                 [TT("General")] = General,
                 [TT("InternetConnexion")] = InternetConnexion,
                 [TT("NetworkStorageRights")] = NetworkStorageRights,

--- a/AccountTester/ExportVariables.cs
+++ b/AccountTester/ExportVariables.cs
@@ -5,60 +5,59 @@
         // Variables for ExportForm, valus are set by the MainForm functions
 
         // General variables
-        public static string General_export_DeviceOS = Convert.ToUInt32(Environment.OSVersion.Version.ToString().Split('.')[2]) >= 22631 ? "Windows 11" : "Windows 10";
+        public static string General_DeviceOS = Convert.ToUInt32(Environment.OSVersion.Version.ToString().Split('.')[2]) >= 22631 ? "Windows 11" : "Windows 10";
 
-        public static string General_export_OSArchitecture = Environment.Is64BitOperatingSystem ? "64 bits" : "32 bits" ?? "Error";
+        public static string General_OSArchitecture = Environment.Is64BitOperatingSystem ? "64 bits" : "32 bits" ?? "Error";
 
-        public static string General_export_UserName = Environment.UserName;
+        public static string General_UserName = Environment.UserName;
 
         public static string General_DateAndHour = DateTime.Now.ToString("dd/MM/yyyy HH:mm:ss");
-        public static int General_export_TotalTests { get; set; }
-        public static int General_export_TotalSuccess { get; set; }
-        public static string General_export_Resume { get; set; } = "Null";
+        public static int General_TotalTests { get; set; }
+        public static int General_TotalSuccess { get; set; }
+        public static string General_Resume { get; set; } = "Null";
 
         // Internet Connection variables
-        public static string InternetConnexion_export_Hour { get; set; } = "Null";
+        public static string InternetConnexion_Hour { get; set; } = "Null";
 
-        public static string InternetConnexion_export_TestedURL = "https://www.google.ch";
-        public static string InternetConnexion_export_HTMLStatut { get; set; } = "Null";
-        public static string InternetConnexion_export_ElapsedTime { get; set; } = "Null";
+        public static string InternetConnexion_TestedURL = "https://www.google.ch";
+        public static string InternetConnexion_HTMLStatut { get; set; } = "Null";
+        public static string InternetConnexion_ElapsedTime { get; set; } = "Null";
 
-        // NetworkStorageRights variables - Not OK, need to be tested with a network share
-        public static string NetworkStorageRights_export_Hour { get; set; } = "Null";
-        public static string NetworkStorageRights_export_ConnexionType { get; set; } = "Null"; // Not set
-        public static string[]? NetworkStorageRights_export_DiskLetter { get; set; }  // Not set
-        public static string[]? NetworkStorageRights_export_CheminUNC { get; set; } // Not set
-        public static string[]? NetworkStorageRights_export_Serveur { get; set; }   // Not set
-        public static string[]? NetworkStorageRights_export_ShareName { get; set; } // Not set
-        public static string NetworkStorageRights_export_ElapsedTime { get; set; } = "Null";
+        // NetworkStorageRights variables - Not OK and need to be tested with a network share 
+        public static string NetworkStorageRights_Hour { get; set; } = "Null";
+        public static string[] NetworkStorageRights_DiskLetter { get; set; } = [];  // Ok with local disk, not test with network share
+        public static string[] NetworkStorageRights_CheminUNC { get; set; } = Array.Empty<string>(); // OK with local disk, not test with network share
+        public static string[] NetworkStorageRights_Serveur { get; set; } = [];   // Ok with local disk, not test with network share
+        public static string[] NetworkStorageRights_ShareName { get; set; } = []; // Ok with local disk, not test with network share
+        public static string NetworkStorageRights_ElapsedTime { get; set; } = "Null";
 
         // OfficeVersion variables
-        public static string OfficeVersion_export_Hour { get; set; } = "Null";
-        public static string OfficeVersion_export_OfficeVersion { get; set; } = "Null";
-        public static string OfficeVersion_export_OfficePath { get; set; } = "Null";
-        public static string OfficeVersion_export_OfficeCulture { get; set; } = "Null";
-        public static string OfficeVersion_export_OfficeExcludedApps { get; set; } = "Null";
-        public static string OfficeVersion_export_OfficeLastUpdateStatus { get; set; } = "Null";
-        public static string OfficeVersion_export_ElapsedTime { get; set; } = "Null";
+        public static string OfficeVersion_Hour { get; set; } = "Null";
+        public static string OfficeVersion_OfficeVersion { get; set; } = "Null";
+        public static string OfficeVersion_OfficePath { get; set; } = "Null";
+        public static string OfficeVersion_OfficeCulture { get; set; } = "Null";
+        public static string OfficeVersion_OfficeExcludedApps { get; set; } = "Null";
+        public static string OfficeVersion_OfficeLastUpdateStatus { get; set; } = "Null";
+        public static string OfficeVersion_ElapsedTime { get; set; } = "Null";
 
         // OfficeRights variables
-        public static string OfficeRights_export_Hour { get; set; } = "Null";
-        public static string OfficeRights_export_Write { get; set; } = "Null";
-        public static string OfficeRights_export_Read { get; set; } = "Null";
-        public static string OfficeRights_export_Delete { get; set; } = "Null";
-        public static string OfficeRights_export_Save { get; set; } = "Null";
-        public static string OfficeRights_export_Create { get; set; } = "Null";
+        public static string OfficeRights_Hour { get; set; } = "Null";
+        public static string OfficeRights_Write { get; set; } = "Null";
+        public static string OfficeRights_Read { get; set; } = "Null";
+        public static string OfficeRights_Delete { get; set; } = "Null";
+        public static string OfficeRights_Save { get; set; } = "Null";
+        public static string OfficeRights_Create { get; set; } = "Null";
 
-        public static string OfficeRights_export_FolderTested = Path.GetTempPath();
-        public static string OfficeRights_export_ElapsedTime { get; set; } = "Null";
+        public static string OfficeRights_FolderTested = Path.GetTempPath();
+        public static string OfficeRights_ElapsedTime { get; set; } = "Null";
 
         // Printer variables
-        public static string Printer_export_Hour { get; set; } = "Null";
-        public static string[] Printer_export_PrinterName { get; set; } = [];
-        public static string[] Printer_export_PrinterIP { get; set; } = [];
-        public static string[] Printer_export_PrinterStatus { get; set; } = [];
-        public static string[] Printer_export_PrinterDriver { get; set; } = [];
-        public static string[] Printer_export_PrinterPort { get; set; } = [];
-        public static string Printer_export_ElapsedTime { get; set; } = "Null";
+        public static string Printer_Hour { get; set; } = "Null";
+        public static string[] Printer_PrinterName { get; set; } = [];
+        public static string[] Printer_PrinterIP { get; set; } = [];
+        public static string[] Printer_PrinterStatus { get; set; } = [];
+        public static string[] Printer_PrinterDriver { get; set; } = [];
+        public static string[] Printer_PrinterPort { get; set; } = [];
+        public static string Printer_ElapsedTime { get; set; } = "Null";
     }
 }

--- a/AccountTester/MainForm.Designer.cs
+++ b/AccountTester/MainForm.Designer.cs
@@ -180,7 +180,7 @@
             MinimizeBox = false;
             Name = "MainForm";
             StartPosition = FormStartPosition.CenterScreen;
-            Text = "Account Tester v0.7.8.2";
+            Text = "Account Tester v0.7.8.5";
             menuStrip1.ResumeLayout(false);
             menuStrip1.PerformLayout();
             ResumeLayout(false);

--- a/AccountTester/strings.Designer.cs
+++ b/AccountTester/strings.Designer.cs
@@ -61,15 +61,6 @@ namespace AccountTester {
         }
         
         /// <summary>
-        ///   Recherche une chaîne localisée semblable à Connexion Type.
-        /// </summary>
-        internal static string ConnexionType {
-            get {
-                return ResourceManager.GetString("ConnexionType", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Recherche une chaîne localisée semblable à Contact.
         /// </summary>
         internal static string Contact {
@@ -259,6 +250,15 @@ namespace AccountTester {
         }
         
         /// <summary>
+        ///   Recherche une chaîne localisée semblable à IO Error.
+        /// </summary>
+        internal static string IOError {
+            get {
+                return ResourceManager.GetString("IOError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Recherche une chaîne localisée semblable à IP.
         /// </summary>
         internal static string IP {
@@ -417,6 +417,15 @@ namespace AccountTester {
         internal static string NetworkStorageRights {
             get {
                 return ResourceManager.GetString("NetworkStorageRights", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Recherche une chaîne localisée semblable à None.
+        /// </summary>
+        internal static string None {
+            get {
+                return ResourceManager.GetString("None", resourceCulture);
             }
         }
         
@@ -745,11 +754,29 @@ namespace AccountTester {
         }
         
         /// <summary>
+        ///   Recherche une chaîne localisée semblable à Unauthorized access.
+        /// </summary>
+        internal static string UnauthorizedAccess {
+            get {
+                return ResourceManager.GetString("UnauthorizedAccess", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Recherche une chaîne localisée semblable à UNC Path.
         /// </summary>
         internal static string UNCPath {
             get {
                 return ResourceManager.GetString("UNCPath", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Recherche une chaîne localisée semblable à Unknown.
+        /// </summary>
+        internal static string Unknown {
+            get {
+                return ResourceManager.GetString("Unknown", resourceCulture);
             }
         }
         

--- a/AccountTester/strings.fr.resx
+++ b/AccountTester/strings.fr.resx
@@ -225,9 +225,6 @@
   <data name="ResponseTime" xml:space="preserve">
     <value>Temps réponse</value>
   </data>
-  <data name="ConnexionType" xml:space="preserve">
-    <value>Type de connexion</value>
-  </data>
   <data name="NetworkStorageRights" xml:space="preserve">
     <value>Droits stockage réseau</value>
   </data>
@@ -362,5 +359,17 @@
   </data>
   <data name="Site" xml:space="preserve">
     <value>Site</value>
+  </data>
+  <data name="Unknown" xml:space="preserve">
+    <value>Inconnu</value>
+  </data>
+  <data name="UnauthorizedAccess" xml:space="preserve">
+    <value>Accès non autorisé</value>
+  </data>
+  <data name="IOError" xml:space="preserve">
+    <value>Erreur IO</value>
+  </data>
+  <data name="None" xml:space="preserve">
+    <value>Aucun</value>
   </data>
 </root>

--- a/AccountTester/strings.resx
+++ b/AccountTester/strings.resx
@@ -225,9 +225,6 @@
   <data name="ResponseTime" xml:space="preserve">
     <value>Response Time</value>
   </data>
-  <data name="ConnexionType" xml:space="preserve">
-    <value>Connexion Type</value>
-  </data>
   <data name="NetworkStorageRights" xml:space="preserve">
     <value>Network Storage Rights</value>
   </data>
@@ -362,5 +359,17 @@
   </data>
   <data name="Site" xml:space="preserve">
     <value>Site</value>
+  </data>
+  <data name="Unknown" xml:space="preserve">
+    <value>Unknown</value>
+  </data>
+  <data name="UnauthorizedAccess" xml:space="preserve">
+    <value>Unauthorized access</value>
+  </data>
+  <data name="IOError" xml:space="preserve">
+    <value>IO Error</value>
+  </data>
+  <data name="None" xml:space="preserve">
+    <value>None</value>
   </data>
 </root>


### PR DESCRIPTION
Mise à jour des noms de variables dans `ExportVariables` en supprimant le suffixe `_export_` pour améliorer la lisibilité. Les références dans `MainForm.cs` ont été ajustées en conséquence.

Ajout de nouvelles chaînes localisées dans les fichiers de ressources pour améliorer l'expérience utilisateur, tout en supprimant les chaînes obsolètes. Des ajustements ont été effectués pour garantir que les tests de connexion et les rapports d'état utilisent les nouvelles variables.