### PR TITLE
Amélioration de la détection des imprimantes partagées

### DIFF
--- a/AccountTester/AccountTester.csproj
+++ b/AccountTester/AccountTester.csproj
@@ -11,8 +11,8 @@
 	<Authors>Miiraak</Authors>
 	<Title></Title>
 	<Copyright>© 2025 Miiraak</Copyright>
-	<Version>0.8.0</Version>
-	<FileVersion>0.8.0</FileVersion>
+	<Version>0.8.0.1</Version>
+	<FileVersion>0.8.0.1</FileVersion>
 	<FileDescription>A software for automated user account rights testing.</FileDescription>
 	<Platforms>AnyCPU</Platforms>
 	<Configurations>Debug;Release;AMD</Configurations>

--- a/AccountTester/MainForm.Designer.cs
+++ b/AccountTester/MainForm.Designer.cs
@@ -343,7 +343,7 @@
             MinimizeBox = false;
             Name = "MainForm";
             StartPosition = FormStartPosition.CenterScreen;
-            Text = "Account Tester v0.8";
+            Text = "Account Tester v0.8.0.1";
             Load += MainFormLoad;
             contextMenuStrip1.ResumeLayout(false);
             menuStrip1.ResumeLayout(false);

--- a/AccountTester/MainForm.cs
+++ b/AccountTester/MainForm.cs
@@ -177,7 +177,8 @@ namespace AccountTester
             }
             catch (Exception ex)
             {
-                MessageBox.Show("Sequential Execution Error : " + Environment.NewLine + ex.Message);
+                MessageBox.Show(ex.ToString(), "Sequential Execution Error");
+                
             }
         }
 

--- a/AccountTester/Tests.cs
+++ b/AccountTester/Tests.cs
@@ -348,8 +348,12 @@ namespace AccountTester
             }
             else
             {
-                foreach (string printer in PrinterSettings.InstalledPrinters)
+                foreach (string printerName in PrinterSettings.InstalledPrinters)
                 {
+                    string printer = printerName;
+                    if (printer.Contains('\\', StringComparison.Ordinal))
+                        printer = printer.Split('\\').Last();
+
                     if (!printer.Contains("Microsoft Print to PDF", StringComparison.OrdinalIgnoreCase) &&
                         !printer.Contains("XPS", StringComparison.OrdinalIgnoreCase) &&
                         !printer.Contains("OneNote", StringComparison.OrdinalIgnoreCase))
@@ -361,8 +365,8 @@ namespace AccountTester
                         if (printerKey != null)
                         {
                             Variables.Printer_PrinterName = Variables.Printer_PrinterName.Append(printer).ToArray();
-                            Variables.Printer_PrinterDriver = Variables.Printer_PrinterDriver.Append(printerKey.GetValue("Printer Driver").ToString()).ToArray();
-                            Variables.Printer_PrinterPort = Variables.Printer_PrinterPort.Append(printerKey.GetValue("Port").ToString()).ToArray();
+                            Variables.Printer_PrinterDriver = Variables.Printer_PrinterDriver.Append(printerKey.GetValue("Printer Driver")?.ToString() ?? T("Unknown")).ToArray();
+                            Variables.Printer_PrinterPort = Variables.Printer_PrinterPort.Append(printerKey.GetValue("Port")?.ToString() ?? T("Unknown")).ToArray();
 
                             string? locationValue = printerKey.GetValue("Location")?.ToString();
                             if (!string.IsNullOrEmpty(locationValue))
@@ -418,10 +422,6 @@ namespace AccountTester
                             Variables.Printer_PrinterDriver = Variables.Printer_PrinterDriver.Append(T("Unknown")).ToArray();
                             Variables.Printer_PrinterPort = Variables.Printer_PrinterPort.Append(T("Unknown")).ToArray();
                         }
-                    }
-                    else
-                    {
-                        rtb.AppendText($"{printer} : {T("Omitted")}" + Environment.NewLine);
                     }
                 }
             }


### PR DESCRIPTION
## Purpose :
- Fix #53 

## Detail :
- Vérification du nom de l'imprimante et split si `\` est détcté. Permet de ping les imprimante partagée.
- Changement du catch dans `MainForm.cs` sequential error.